### PR TITLE
Set host/namespace defaults to use ember-cli express server

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,10 @@ if (environment === 'production') {
 }
 ```
 
-If no API host is set, the adapter will use http://localhost:8000 by default.
+### Configuration Options
+
+* API_HOST: The server hosting your API _(default: None)_
+* API_NAMESPACE: Your API namespace _(default: 'api')_
 
 
 Extending

--- a/app-addon/initializers/django-adapter.js
+++ b/app-addon/initializers/django-adapter.js
@@ -1,10 +1,21 @@
 export default {
   name: "django-adapter",
+
   initialize: function(container, app) {
-    var djangoAdapterConfig = {
-      apiHost: app.get('API_HOST') || 'http://localhost:8000',
-      apiNamespace: app.get('API_NAMESPACE') || ''
+
+    var getConfig = function(configKey, defaultValue) {
+      if (typeof app.get(configKey) !== 'undefined') {
+        return app.get(configKey);
+      } else {
+        return defaultValue;
+      }
     };
+
+    var djangoAdapterConfig = {
+      apiHost: getConfig('API_HOST'),
+      apiNamespace: getConfig('API_NAMESPACE', 'api')
+    };
+
     app.register('config:djangoAdapterConfig', djangoAdapterConfig, { instantiate: false });
     app.inject('adapter', 'djangoAdapterConfig', 'config:djangoAdapterConfig');
   }


### PR DESCRIPTION
With the the express server [being exposed](https://github.com/stefanpenner/ember-cli/pull/683) to custom user routes, this is a more viable option for out of the box development rather than relying on a running Django instance.

By default, the custom routes are name-spaced with "api", so we'll make this the default configuration in ember-django-adapter.
