### PR TITLE
Fix for "Cannot read property 'pkg' of null" error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ember-django-adapter Changelog
 ==============================
 
+* [BUGFIX] Fix for #7
 * [ENHANCEMENT] Simplify addon packaging
   ([#5](https://github.com/dustinfarris/ember-django-adapter/pull/5))
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "ember-addon"
   ],
   "ember-addon": {
-    "after": "ember-cli-ember-data"
+    "after": "ember-data"
   },
   "repository": "https://github.com/dustinfarris/ember-django-adapter",
   "author": "Dustin Farris",


### PR DESCRIPTION
```
- The ember-cli-ember-data addon is deprecated
  switched the dependency to ember-data instead
```

Installed with npm from my local copy and it worked for me. I'm now being able to see "ember-data-django-rest-adapter" in info section of ember inspector

Not sure if it closes #6 as I wasn't able to reproduce this.

This means we now depend on ember-cli >= 0.4.5, but there are probably still issues with ember-data itself (1.0-BETA-10) and the adapter, so it's probably better to do a new release after this is done: https://github.com/toranb/ember-data-django-rest-adapter/pull/101
