### PR TITLE
Use pluralized and dasherized model name in pathForType.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,23 +81,24 @@ ember generate django-serializer my-custom-serializer
 
 ## Path Customization
 
-By default the DjangoRESTAdapter will attempt to use the pluralized lowercase model name to generate the path name. This
-allows some features in Django REST Framework to work by default. If this convention is not suitable for your needs,
-you can override the pathForType method.
+By default the `DRFAdapter` will attempt to pluralize and
+dasherize the  model name to generate the path name. This allows the
+convention of URLs in Django. If this convention is not suitable for
+your needs, you can override the pathForType method.
 
-For example, if you do not want to use the default lowercase model names and needed dashed-case instead, you would
-override the pathForType method like this:
+For example, if you do not want to pluralize and dasherize the model
+names and needed underscore_case instead, you would override the
+pathForType method like this:
 
 ```js
 App.ApplicationAdapter = DS.DjangoRESTAdapter.extend({
   pathForType: function(type) {
-    var dasherized = Ember.String.dasherize(type);
-    return Ember.String.pluralize(dasherized);
+    return Ember.String.underscore(type);
   }
 });
 ```
 
-Requests for App.User would now target /users/1. Requests for App.UserProfile would now target /user-profiles/1.
+Requests for App.User would now target /user/1. Requests for App.UserProfile would now target /user_profile/1.
 
 
 ## coalesceFindRequests option

--- a/addon/adapters/drf.js
+++ b/addon/adapters/drf.js
@@ -40,8 +40,8 @@ export default DS.RESTAdapter.extend({
    * @return {String} path
    */
   pathForType: function(type) {
-    var lowerCaseType = type.toLowerCase();
-    return Ember.String.pluralize(lowerCaseType);
+    var dasherized = Ember.String.dasherize(type);
+    return Ember.String.pluralize(dasherized);
   },
 
   /**

--- a/tests/unit/adapters/drf-test.js
+++ b/tests/unit/adapters/drf-test.js
@@ -20,9 +20,11 @@ test('namespace config override', function() {
 test('pathForType', function() {
   var adapter = this.subject();
   equal(adapter.pathForType('Animal'), 'animals');
+  equal(adapter.pathForType('FurryAnimals'), 'furry-animals');
 });
 
 test('buildURL', function() {
   var adapter = this.subject();
   equal(adapter.buildURL('Animal', 5, null), 'test-host/test-api/animals/5/');
+  equal(adapter.buildURL('FurryAnimals', 5, null), 'test-host/test-api/furry-animals/5/');
 });


### PR DESCRIPTION
This is a fix for #19.
