### PR TITLE
Add docs and GitHub Pages deployment automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /.sass-cache
 /connect.lock
 /coverage/*
+/site
 /libpeerconnection.log
 npm-debug.log
 testem.log

--- a/circle.yml
+++ b/circle.yml
@@ -3,3 +3,10 @@ dependencies:
     - npm install -g bower
     - npm install
     - bower install
+
+deployment:
+  production:
+    branch: version-1.0
+    commands:
+      - sudo pip install mkdocs
+      - mkdocs gh-deploy

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,1 @@
+../CHANGELOG.md

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,9 @@
+# Contributing to Ember Django Adapter
+
+We welcome all bug reports and pull requests.
+
+Issues: [github.com/dustinfarris/ember-django-adapter/issues][1]
+
+
+
+[1]: https://github.com/dustinfarris/ember-django-adapter/issues

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,24 @@
+# Ember Django Adapter Documentation
+
+Ember Django Adapter (EDA) enables users to build applications using Django REST Framework and
+Ember.js.  The two packages work with REST APIs, but differ on certain JSON formatting and
+semantics.  Fortunately, Ember Data (the library powering Ember.js models) provides an opportunity
+to write custom adapters to bridge these differences.  EDA is one such adapter specifically
+designed to work with Django REST Framework.
+
+
+## Requirements
+
+To build a project using Ember Django Adapter, you will need to be using:
+
+* Django REST Framwork >= 3.0
+* Ember CLI >= 0.1.0
+
+
+## Quickstart
+
+In your Ember CLI project, install Ember Django Adapter from the command line:
+
+```bash
+npm install --save-dev ember-django-adapter
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,7 @@
+site_name: Ember Django Adapter
+repo_url: https://github.com/dustinfarris/ember-django-adapter
+pages:
+  - ['index.md', 'Introduction']
+  - ['contributing.md']
+  - ['changelog.md']
+theme: readthedocs


### PR DESCRIPTION
This adds the mkdocs file structure and some very basic documentation to get the ball rolling.

Also included is some automation with CircleCI to automatically deploy to GitHub Pages when a commit is made to the _version-1.0_ branch.  Eventually we'll change that to _master_.

Add docs by editing or adding to markdown in the docs directory.  Preview with `pip install mkdocs && mkdocs serve` from the root directory.  When a pull-request is accepted, CircleCI will deploy it to the live site.

Right now the site lives at [dustinfarris.com/ember-django-adapter](http://dustinfarris.com/ember-django-adapter/).  Apparently, GitHub picked up the CNAME from my primary user GitHub Pages site and extended it here.  I guess it can stay like that for now until/if we decide to purchase a domain.
