### PR TITLE
Add option to remove trailing slashes

### DIFF
--- a/addon/adapters/drf.js
+++ b/addon/adapters/drf.js
@@ -53,6 +53,9 @@ export default DS.RESTAdapter.extend({
    * If an ID is specified, it adds the ID to the path generated for
    * the type, separated by a `/`.
    *
+   * If the adapter has the property `add_trailing_slashes` set to
+   * true, a trailing slash will be appended to the result.
+   *
    * @method buildURL
    * @param {String} type
    * @param {String} id
@@ -61,8 +64,10 @@ export default DS.RESTAdapter.extend({
    */
   buildURL: function(type, id, record) {
     var url = this._super(type, id, record);
-    if (url.charAt(url.length - 1) !== '/') {
-      url += '/';
+    if (this.get('add_trailing_slashes')) {
+      if (url.charAt(url.length - 1) !== '/') {
+        url += '/';
+      }
     }
     return url;
   },

--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -8,5 +8,9 @@ export default DRFAdapter.extend({
 
   namespace: function() {
     return ENV.APP.API_NAMESPACE;
+  }.property(),
+
+  add_trailing_slashes: function() {
+    return ENV.APP.API_ADD_TRAILING_SLASHES;
   }.property()
 });

--- a/config/environment.js
+++ b/config/environment.js
@@ -4,7 +4,8 @@ module.exports = function(/* environment, appConfig */) {
   var ENV = {
     APP: {
       API_HOST: '',
-      API_NAMESPACE: 'api'
+      API_NAMESPACE: 'api',
+      API_ADD_TRAILING_SLASHES: true
     }
   };
   return ENV;

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -1,0 +1,51 @@
+# Configuring
+
+There are a number of configuration variables you can set in your environment.js file.
+
+
+## API_HOST
+
+**Default:** `''`
+
+The fully-qualified host of your API server.
+
+
+## API_NAMESPACE
+
+**Default:** `'api'`
+
+The URL prefix (namespace) for your API.  In other words, if you set this to my-api/v1, then all
+API requests will look like /my-api/v1/users/56/, or similar.
+
+
+## API_ADD_TRAILING_SLASHES
+
+**Default:** `true`
+
+Whether to append a trailing slash to API URL endpoints.
+
+
+## Example
+
+```js
+// my-ember-cli-project/config/environment.js
+
+module.exports = function(environment) {
+  var ENV = {
+    APP: {
+      API_ADD_TRAILING_SLASHES: false
+    }
+  };
+
+  if (environment === 'development') {
+    ENV.APP.API_HOST = 'http://localhost:8000';
+  }
+
+  if (environment === 'production') {
+    ENV.APP.API_HOST = 'https://api.myproject.com';
+    ENV.APP.NAMESPACE = 'v2';
+  }
+
+  return ENV;
+};
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,3 +23,5 @@ In your Ember CLI project, install Ember Django Adapter from the command line:
 ```bash
 npm install --save-dev ember-django-adapter
 ```
+
+See [configuring](configuring.md) for more information on customizing the adapter.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,7 @@ site_name: Ember Django Adapter
 repo_url: https://github.com/dustinfarris/ember-django-adapter
 pages:
   - ['index.md', 'Introduction']
+  - ['configuring.md']
   - ['pagination.md']
   - ['contributing.md']
   - ['changelog.md']

--- a/tests/unit/adapters/drf-test.js
+++ b/tests/unit/adapters/drf-test.js
@@ -32,6 +32,13 @@ test('buildURL', function() {
   equal(adapter.buildURL('FurryAnimals', 5, null), 'test-host/test-api/furry-animals/5/');
 });
 
+test('buildURL - no trailing slashes', function() {
+  var adapter = this.subject();
+  adapter.set('add_trailing_slashes', false);
+  equal(adapter.buildURL('Animal', 5, null), 'test-host/test-api/animals/5');
+  equal(adapter.buildURL('FurryAnimals', 5, null), 'test-host/test-api/furry-animals/5');
+});
+
 test('ajaxError - returns invalid error if 400 response', function() {
   var error = new DS.InvalidError({errors: {name: ['This field cannot be blank.']}});
 


### PR DESCRIPTION
This PR adds a new option to remove trailing slashes from API URLs.

Example usage:

```js
// in your app's config/environment.js

var ENV = {
  APP: {
    API_ADD_TRAILING_SLASHES: false
    ...
  }
};
```