### PR TITLE
Change default `API_HOST`

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -3,7 +3,7 @@
 module.exports = function(/* environment, appConfig */) {
   var ENV = {
     APP: {
-      API_HOST: '',
+      API_HOST: 'http://localhost:8000',
       API_NAMESPACE: 'api',
       API_ADD_TRAILING_SLASHES: true
     }

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -5,7 +5,7 @@ There are a number of configuration variables you can set in your environment.js
 
 ## API_HOST
 
-**Default:** `''`
+**Default:** `'http://localhost:8000'`
 
 The fully-qualified host of your API server.
 


### PR DESCRIPTION
This adds a more reasonable default for `API_HOST`.  The existing empty string would just point the adapter at Ember's express server, which makes no sense in DRF world.

Should fix #4.