### PR TITLE
Move trailing slashes config

### DIFF
--- a/addon/adapters/drf.js
+++ b/addon/adapters/drf.js
@@ -31,6 +31,7 @@ export default DS.RESTAdapter.extend({
       throw new Ember.Error(error);
     }
   },
+  addTrailingSlashes: true,
 
   /**
    * Determine the pathname for a given type.
@@ -53,7 +54,7 @@ export default DS.RESTAdapter.extend({
    * If an ID is specified, it adds the ID to the path generated for
    * the type, separated by a `/`.
    *
-   * If the adapter has the property `add_trailing_slashes` set to
+   * If the adapter has the property `addTrailingSlashes` set to
    * true, a trailing slash will be appended to the result.
    *
    * @method buildURL
@@ -64,7 +65,7 @@ export default DS.RESTAdapter.extend({
    */
   buildURL: function(type, id, record) {
     var url = this._super(type, id, record);
-    if (this.get('add_trailing_slashes')) {
+    if (this.get('addTrailingSlashes')) {
       if (url.charAt(url.length - 1) !== '/') {
         url += '/';
       }

--- a/app/adapters/drf.js
+++ b/app/adapters/drf.js
@@ -8,9 +8,5 @@ export default DRFAdapter.extend({
 
   namespace: function() {
     return ENV.APP.API_NAMESPACE;
-  }.property(),
-
-  add_trailing_slashes: function() {
-    return ENV.APP.API_ADD_TRAILING_SLASHES;
   }.property()
 });

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -18,13 +18,6 @@ The URL prefix (namespace) for your API.  In other words, if you set this to my-
 API requests will look like /my-api/v1/users/56/, or similar.
 
 
-## API_ADD_TRAILING_SLASHES
-
-**Default:** `true`
-
-Whether to append a trailing slash to API URL endpoints.
-
-
 ## Example
 
 ```js
@@ -33,7 +26,6 @@ Whether to append a trailing slash to API URL endpoints.
 module.exports = function(environment) {
   var ENV = {
     APP: {
-      API_ADD_TRAILING_SLASHES: false
     }
   };
 

--- a/docs/trailing-slashes.md
+++ b/docs/trailing-slashes.md
@@ -1,0 +1,28 @@
+# Trailing Slashes
+
+
+By default, Django REST Framework adds trailing slashes to its generated URLs.
+EDA is set up to handle this, however, if you have decided to opt out of
+trailing slashes, you will need to extend the adapter with this configuration.
+
+e.g., if you have set up a router in DRF that is instantiated like this:
+
+```python
+from rest_framework import routers
+
+
+router = routers.DefaultRouter(trailing_slash=False)
+```
+
+then you will need to [extend](extending.md) the adapter and switch off
+`addTrailingSlashes` in `app/adapters/application.js`:
+
+```js
+// app/adapters/application.js
+
+import DRFAdapter from './drf';
+
+export default DRFAdapter.extend({
+  addTrailingSlashes: false
+});
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,7 @@ pages:
   - ['index.md', 'Introduction']
   - ['configuring.md']
   - ['extending.md']
+  - ['trailing-slashes.md']
   - ['embedded-records.md']
   - ['pagination.md']
   - ['contributing.md']

--- a/tests/unit/adapters/drf-test.js
+++ b/tests/unit/adapters/drf-test.js
@@ -34,7 +34,7 @@ test('buildURL', function() {
 
 test('buildURL - no trailing slashes', function() {
   var adapter = this.subject();
-  adapter.set('add_trailing_slashes', false);
+  adapter.set('addTrailingSlashes', false);
   equal(adapter.buildURL('Animal', 5, null), 'test-host/test-api/animals/5');
   equal(adapter.buildURL('FurryAnimals', 5, null), 'test-host/test-api/furry-animals/5');
 });


### PR DESCRIPTION
The trailing slashes config isn't really something that changes between environments, so it shouldn't be configured as such.

This PR redefines how addTrailingSlashes is configured.

This is a breaking change.