### PR TITLE
Add support for coalesceFindRequests

### DIFF
--- a/addon/adapters/drf.js
+++ b/addon/adapters/drf.js
@@ -15,23 +15,8 @@ import Ember from 'ember';
  */
 export default DS.RESTAdapter.extend({
   defaultSerializer: "DS/djangoREST",
-
-  init: function() {
-    this._super();
-
-    if (this.get('coalesceFindRequests')) {
-      var error = "Please ensure coalesceFindRequests is not present or set " +
-        "to false in your adapter. This adapter does not support the " +
-        "coalesceFindRequests option. The Django REST Framework does not " +
-        "offer easy to configure support for N+1 query requests in the " +
-        "format that Ember Data uses (e.g. GET /comments?ids[]=1&ids[]=2) " +
-        "See the Ember documentation about coalesceFindRequests for " +
-        "information about this option: " +
-        "http://emberjs.com/api/data/classes/DS.RESTAdapter.html#property_coalesceFindRequests";
-      throw new Ember.Error(error);
-    }
-  },
   addTrailingSlashes: true,
+  coalesceFindRequests: false,
 
   /**
    * Determine the pathname for a given type.
@@ -111,5 +96,21 @@ export default DS.RESTAdapter.extend({
     } else {
       return error;
     }
+  },
+
+  /**
+   * This is used by RESTAdapter.groupRecordsForFindMany.
+   *
+   * The original implementation is a complex stripping of the id from
+   * the URL, which can be dramatically simplified by just returning
+   * the base URL for the type.
+   *
+   * @method _stripIDFromURL
+   * @param {DS.Store} store
+   * @param {DS.Model} record
+   * @return {String} url
+   */
+  _stripIDFromURL: function(store, record) {
+    return this.buildURL(record.constructor.typeKey);
   }
 });

--- a/addon/adapters/drf.js
+++ b/addon/adapters/drf.js
@@ -99,11 +99,31 @@ export default DS.RESTAdapter.extend({
   },
 
   /**
+   * Fetch several records together if `coalesceFindRequests` is true.
+   *
+   * @method findMany
+   * @param {DS.Store} store
+   * @param {subclass of DS.Model} type
+   * @param {Array} ids
+   * @param {Array} records
+   * @return {Promise} promise
+   */
+  findMany: function(store, type, ids, records) {
+    Ember.Logger.warn('WARNING: You are fetching several records in a single request because ' +
+                      'you have set `coalesceFindRequests=true` on the adapter.  For this to ' +
+                      'work, you MUST implement a custom filter in Django REST Framework.  See ' +
+                      'http://dustinfarris.com/ember-django-adapter/coalesce-find-requests/ ' +
+                      'for more information.');
+    return this._super(store, type, ids, records);
+  },
+
+  /**
    * This is used by RESTAdapter.groupRecordsForFindMany.
    *
-   * The original implementation is a complex stripping of the id from
-   * the URL, which can be dramatically simplified by just returning
-   * the base URL for the type.
+   * The original implementation does not handle trailing slashes well.
+   * Additionally, it is a complex stripping of the id from the URL,
+   * which can be dramatically simplified by just returning the base
+   * URL for the type.
    *
    * @method _stripIDFromURL
    * @param {DS.Store} store

--- a/addon/adapters/drf.js
+++ b/addon/adapters/drf.js
@@ -16,7 +16,6 @@ import Ember from 'ember';
 export default DS.RESTAdapter.extend({
   defaultSerializer: "DS/djangoREST",
   addTrailingSlashes: true,
-  coalesceFindRequests: false,
 
   /**
    * Determine the pathname for a given type.

--- a/docs/coalesce-find-requests.md
+++ b/docs/coalesce-find-requests.md
@@ -1,0 +1,160 @@
+# Coalescing Find Requests
+
+When a record returns the IDs of records in a hasMany relationship, Ember Data
+allows us to opt-in to combine these requests into a single request.
+
+Suppose you have Ember models:
+
+```js
+// app/models/person.js
+
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  name: DS.attr('string'),
+  pets: DS.hasMany('pet', { async: True })
+});
+
+
+// app/models/pet.js
+
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  age: DS.attr('number')
+});
+```
+
+An out-of-the-box DRF model serializer for Person would return something like
+this:
+
+```
+GET /api/people/1/
+
+{
+  "id": 1,
+  "name": "Fred",
+  "pets": [1, 2, 3]
+}
+```
+
+When Ember Data decides to resolve the pets, by default it would fire 3
+separate requests.  In this case:
+
+```
+GET /api/pets/1/
+
+{
+  "id": 1,
+  "age": 5
+}
+
+GET /api/pets/2/
+
+{
+  "id": 2,
+  "age": 5
+}
+
+GET /api/pets/3/
+
+{
+  "id": 3,
+  "age": 6
+}
+```
+
+However, if we opt-in to coalesceFindRequests, we can consolidate this into
+1 call.
+
+
+## Enable coalesceFindRequests
+
+[Extend](extending.md) the adapter, and enable coalesceFindRequests:
+
+```js
+// app/adapters/application.js
+
+import DRFAdapter from './drf';
+
+export default DRFAdapter.extend({
+  coalesceFindRequests: true
+});
+```
+
+Now, when Ember Data resolves the pets, it will fire a request that looks like
+this:
+
+```
+GET /api/pets/?ids[]=1&ids[]=2&ids[]=3
+```
+
+
+## CoalesceFilterBackend
+
+All this is great, except Django REST Framework is not quite able to handle such a
+request out of the box.  Thankfully, DRF
+[allows you to plug in custom filters](http://www.django-rest-framework.org/api-guide/filtering/#setting-filter-backends),
+and writing a filter for this kind of request is super simple.
+
+In your project somewhere, write the following filter:
+
+```python
+# myapp/filters.py
+
+from rest_framework import filters
+
+
+class CoalesceFilterBackend(filters.BaseFilterBackend):
+    """
+    Support Ember Data coalesceFindRequests.
+
+    """
+    def filter_queryset(self, request, queryset, view):
+        id_list = request.QUERY_PARAMS.getlist('ids[]')
+        if id_list:
+            queryset = queryset.filter(id__in=id_list)
+        return queryset
+```
+
+Now you just need to add this filter to `filter_backends` in your views, e.g.:
+
+```python
+from myapp.filters import CoalesceFilterBackend
+
+
+class UserListView(generics.ListAPIView):
+    queryset = User.objects.all()
+    serializer = UserSerializer
+    filter_backends = (CoalesceFilterBackend,)
+```
+
+Or, configure it globally in your DRF settings:
+
+```python
+REST_FRAMEWORK = {
+    'DEFAULT_FILTER_BACKENDS': ('myapp.filters.CoalesceFilterBackend',)
+}
+```
+
+Now, when Ember Data sends the coalesced request, DRF will return meaningful
+data:
+
+```
+GET /api/pets/?ids[]=1&ids[]=2&ids[]=3
+
+[
+  {
+    "id": 1,
+    "age": 5
+  },
+  {
+    "id": 2,
+    "age": 5
+  },
+  {
+    "id": 3,
+    "age": 6
+  }
+]
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,7 @@ pages:
   - ['trailing-slashes.md']
   - ['embedded-records.md']
   - ['pagination.md']
+  - ['coalesce-find-requests.md']
   - ['contributing.md']
   - ['changelog.md']
 theme: readthedocs

--- a/tests/unit/adapters/drf-test.js
+++ b/tests/unit/adapters/drf-test.js
@@ -80,3 +80,22 @@ test('ajaxError - returns ajax response if no status returned', function() {
   var adapter = this.subject();
   equal(adapter.ajaxError(jqXHR), jqXHR);
 });
+
+test('_stripIDFromURL - returns base URL for type', function() {
+  var record = {
+    constructor: { typeKey: 'furry-animal' }
+  };
+  var adapter = this.subject();
+
+  equal(adapter._stripIDFromURL('store', record), 'test-host/test-api/furry-animals/');
+});
+
+test('_stripIDFromURL without trailing slash - returns base URL for type', function() {
+  var record = {
+    constructor: { typeKey: 'furry-animal' }
+  };
+  var adapter = this.subject();
+  adapter.set('addTrailingSlashes', false);
+
+  equal(adapter._stripIDFromURL('store', record), 'test-host/test-api/furry-animals');
+});


### PR DESCRIPTION
This adds documentation that describes how to write a simple filter in DRF to support coalesced requests.  Additionally, we override `_stripIDFromURL` so that it can handle trailing slashes.

The [original `_stripIDFromURL`](https://github.com/emberjs/data/blob/master/packages/ember-data/lib/adapters/rest_adapter.js#L594-L610) implementation seems overly complicated, so I chose to simplify it down to a simple proxy to buildURL call with the record type.

Thanks to @g-cassie for inspiration on the DRF filter.

Fixes #32 