### PR TITLE
Add Google Analytics to docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,3 +10,4 @@ pages:
   - ['contributing.md']
   - ['changelog.md']
 theme: readthedocs
+google_analytics: ['UA-13275015-13', 'auto']


### PR DESCRIPTION
This is good to go, but it won't actually work until https://github.com/tomchristie/mkdocs/pull/338 is merged.