### PR TITLE
Updated docs and param name in serializer to fit changes in ED 1.0.0-Bet...

### DIFF
--- a/addon/serializers/drf.js
+++ b/addon/serializers/drf.js
@@ -113,11 +113,11 @@ export default DS.RESTSerializer.extend({
    * @method serializeIntoHash
    * @param {Object} hash
    * @param {subclass of DS.Model} type
-   * @param {DS.Model} record
+   * @param {DS.Snapshot} snapshot
    * @param {Object} options
    */
-  serializeIntoHash: function(hash, type, record, options) {
-    Ember.merge(hash, this.serialize(record, options));
+  serializeIntoHash: function(hash, type, snapshot, options) {
+    Ember.merge(hash, this.serialize(snapshot, options));
   },
 
   /**


### PR DESCRIPTION
...a.15

    - Latest Ember Data added a snapshot API, which is
      passed to the serializer instead of the record instance
      http://emberjs.com/blog/2015/02/14/ember-data-1-0-beta-15-released.html