### PR TITLE
rename deprecated method name to fit ED 1.0.0.beta15

### DIFF
--- a/addon/serializers/drf.js
+++ b/addon/serializers/drf.js
@@ -44,7 +44,7 @@ export default DS.RESTSerializer.extend({
   extractMeta: function(store, type, payload) {
     if (payload && payload.results) {
       // Sets the metadata for the type.
-      store.metaForType(type, {
+      store.setMetadataFor(type, {
         count: payload.count,
         next: this.extractPageNumber(payload.next),
         previous: this.extractPageNumber(payload.previous)


### PR DESCRIPTION
Hello! I'm using ED 1.0.0 beta 15 and getting a deprecation warning. Apparently they change the name of `store.metaForType` to `store.setMetadataFor`. This pull request fix the problem.

I hope this help!