### PR TITLE
Removed store.metaForType() to use store.setMetadataFor()

### DIFF
--- a/addon/serializers/drf.js
+++ b/addon/serializers/drf.js
@@ -44,7 +44,7 @@ export default DS.RESTSerializer.extend({
   extractMeta: function(store, type, payload) {
     if (payload && payload.results) {
       // Sets the metadata for the type.
-      store.metaForType(type, {
+      store.setMetadataFor(type, {
         count: payload.count,
         next: this.extractPageNumber(payload.next),
         previous: this.extractPageNumber(payload.previous)


### PR DESCRIPTION
Fixed deprecation message.

![screen shot 2015-04-01 at 12 16 15 am](https://cloud.githubusercontent.com/assets/6109151/6934737/7d39c34c-d807-11e4-8383-0a99d72788b9.png)