### PR TITLE
Add `ember try` scenarios

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,0 +1,16 @@
+module.exports = {
+  scenarios: [
+    {
+      name: 'ember-data-beta',
+      dependencies: {
+        'ember-data': '1.0.0-beta.16.1'
+      }
+    },
+    {
+      name: 'ember-data-canary',
+      dependencies: {
+        'ember-data': 'canary'
+      }
+    }
+  ]
+};

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -31,5 +31,19 @@ Now your test project is using a symlinked copy of your local ember-django-adapt
 you make to the adapter will be reflected in your project in real-time.
 
 
+## Running tests
+
+You can run tests with the latest supported Ember Data beta with:
+
+```
+ember test
+```
+
+You can also run tests against Ember Data canary with:
+
+```
+ember try ember-data-canary
+```
+
 
 [1]: https://github.com/dustinfarris/ember-django-adapter/issues

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "start": "ember server",
     "build": "ember build",
-    "test": "ember try:testall"
+    "test": "ember test"
   },
   "repository": "https://github.com/dustinfarris/ember-django-adapter",
   "engines": {


### PR DESCRIPTION
Playing with [ember-try](https://www.npmjs.com/package/ember-try).  This lays the groundwork for eventually supporting a dependency matrix.  For now, I think we should just support the latest ED beta until 1.0 lands.  At that point we'll want to be careful about breaking changes for >=1.0.

You can invoke ember try with:

```
ember try:testall
```

which runs all scenarios in `config/ember-try.js` (latest ember data beta and ember data canary).  You can run a specific scenario by giving its name, e.g.:

```
ember try ember-data-canary
```

(side note: we have 2 failing tests on canary)