### PR TITLE
Use `snapshot.typeKey` on adapter's _stripIDFromUrl

### DIFF
--- a/addon/adapters/drf.js
+++ b/addon/adapters/drf.js
@@ -130,6 +130,6 @@ export default DS.RESTAdapter.extend({
    * @return {String} url
    */
   _stripIDFromURL: function(store, snapshot) {
-    return this.buildURL(snapshot.constructor.typeKey);
+    return this.buildURL(snapshot.typeKey);
   }
 });

--- a/tests/unit/adapters/drf-test.js
+++ b/tests/unit/adapters/drf-test.js
@@ -85,20 +85,20 @@ test('ajaxError - returns ajax response if no status returned', function(assert)
 });
 
 test('_stripIDFromURL - returns base URL for type', function(assert) {
-  var record = {
-    constructor: { typeKey: 'furry-animal' }
+  var snapshot = {
+    typeKey: 'furry-animal'
   };
   var adapter = this.subject();
 
-  assert.equal(adapter._stripIDFromURL('store', record), 'test-host/test-api/furry-animals/');
+  assert.equal(adapter._stripIDFromURL('store', snapshot), 'test-host/test-api/furry-animals/');
 });
 
 test('_stripIDFromURL without trailing slash - returns base URL for type', function(assert) {
-  var record = {
-    constructor: { typeKey: 'furry-animal' }
+  var snapshot = {
+    typeKey: 'furry-animal'
   };
   var adapter = this.subject();
   adapter.set('addTrailingSlashes', false);
 
-  assert.equal(adapter._stripIDFromURL('store', record), 'test-host/test-api/furry-animals');
+  assert.equal(adapter._stripIDFromURL('store', snapshot), 'test-host/test-api/furry-animals');
 });


### PR DESCRIPTION
Using `snapshot.constructor.typeKey` is deprecated on latest `ember-data`.

`snapshot.typeKey` reference: http://emberjs.com/api/data/classes/DS.Snapshot.html#property_typeKey