### PR TITLE
Add requestType to buildURL.

### DIFF
--- a/addon/adapters/drf.js
+++ b/addon/adapters/drf.js
@@ -47,8 +47,8 @@ export default DS.RESTAdapter.extend({
    * @param {DS.Snapshot} snapshot
    * @return {String} url
    */
-  buildURL: function(type, id, snapshot) {
-    var url = this._super(type, id, snapshot);
+  buildURL: function(type, id, snapshot, requestType) {
+    var url = this._super(type, id, snapshot, requestType);
     if (this.get('addTrailingSlashes')) {
       if (url.charAt(url.length - 1) !== '/') {
         url += '/';


### PR DESCRIPTION
This allows for other types of find queries to be handled correctly, e.g. `store.find('person', {name: 'Ben'});`.

Without this, the default findById method is used, and Ember Data URI encodes the object, producing malformed URLs.