### PR TITLE
Updated for ember-data@1.0.0-beta.18

### DIFF
--- a/addon/adapters/drf.js
+++ b/addon/adapters/drf.js
@@ -130,6 +130,6 @@ export default DS.RESTAdapter.extend({
    * @return {String} url
    */
   _stripIDFromURL: function(store, snapshot) {
-    return this.buildURL(snapshot.typeKey);
+    return this.buildURL(snapshot.modelName);
   }
 });

--- a/addon/serializers/drf.js
+++ b/addon/serializers/drf.js
@@ -70,7 +70,7 @@ export default DS.RESTSerializer.extend({
    */
   extractSingle: function(store, type, payload, id) {
     var convertedPayload = {};
-    convertedPayload[type.typeKey] = payload;
+    convertedPayload[type.modelName] = payload;
     return this._super(store, type, convertedPayload, id);
   },
 
@@ -91,9 +91,9 @@ export default DS.RESTSerializer.extend({
     // because `results` will only be in lists.
     var convertedPayload = {};
     if (payload.results) {
-      convertedPayload[type.typeKey] = payload.results;
+      convertedPayload[type.modelName] = payload.results;
     } else {
-      convertedPayload[type.typeKey] = payload;
+      convertedPayload[type.modelName] = payload;
     }
     return this._super(store, type, convertedPayload);
   },

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
     "ember": "1.12.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-data": "1.0.0-beta.17",
+    "ember-data": "1.0.0-beta.18",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.4",
     "ember-qunit": "0.3.3",
     "ember-qunit-notifications": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "ember-cli-pretender": "0.3.2",
     "ember-cli-qunit": "0.3.13",
     "ember-cli-uglify": "^1.0.1",
-    "ember-data": "1.0.0-beta.17",
+    "ember-data": "1.0.0-beta.18",
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^0.7.0",
     "ember-export-application-global": "^1.0.2",

--- a/tests/unit/adapters/drf-test.js
+++ b/tests/unit/adapters/drf-test.js
@@ -86,7 +86,7 @@ test('ajaxError - returns ajax response if no status returned', function(assert)
 
 test('_stripIDFromURL - returns base URL for type', function(assert) {
   var snapshot = {
-    typeKey: 'furry-animal'
+    modelName: 'furry-animal'
   };
   var adapter = this.subject();
 
@@ -95,7 +95,7 @@ test('_stripIDFromURL - returns base URL for type', function(assert) {
 
 test('_stripIDFromURL without trailing slash - returns base URL for type', function(assert) {
   var snapshot = {
-    typeKey: 'furry-animal'
+    modelName: 'furry-animal'
   };
   var adapter = this.subject();
   adapter.set('addTrailingSlashes', false);

--- a/tests/unit/serializers/drf-test.js
+++ b/tests/unit/serializers/drf-test.js
@@ -10,7 +10,7 @@ moduleFor('serializer:application', 'DRFSerializer', { });
 test('extractSingle', function(assert) {
   var serializer = this.subject();
   serializer._super = sinon.stub().returns('extracted single');
-  var type = { typeKey: 'person' };
+  var type = { modelName: 'person' };
 
   var result = serializer.extractSingle('store', type, 'payload', 'id');
 
@@ -23,7 +23,7 @@ test('extractSingle', function(assert) {
 test('extractArray - results', function(assert) {
   var serializer = this.subject();
   serializer._super = sinon.stub().returns('extracted array');
-  var type = { typeKey: 'person' };
+  var type = { modelName: 'person' };
   var payload = { other: 'stuff', results: ['result'] };
 
   var result = serializer.extractArray('store', type, payload);
@@ -37,7 +37,7 @@ test('extractArray - results', function(assert) {
 test('extractArray - no results', function(assert) {
   var serializer = this.subject();
   serializer._super = sinon.stub().returns('extracted array');
-  var type = { typeKey: 'person' };
+  var type = { modelName: 'person' };
   var payload = { other: 'stuff' };
 
   var result = serializer.extractArray('store', type, payload);


### PR DESCRIPTION
Hey, it's me again. Newest beta introduced some more changes to reference the type for a `Snapshot`/`Model`.
`typeKey` and `constructor.typeKey` are now deprecated and both use the `modelName` property instead.

Updated the usage of those attributes, their respective tests, and both node and bower dependencies to point at the latest beta.
Let me know in any case!