### PR TITLE
Updating adapter to support ember-data 1.13.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ To that end, Ember Data encourages the use of adapters to manage communication w
 various backend APIs.
 
 This adapter enables the use of [Django REST Framework][] as an API backend for
-Ember Data.  The addon is compatible with [ember-cli][] version 0.2.7 and higher, and
-Ember Data v1.0.0-beta.19.
+Ember Data.  The addon is compatible with [ember-cli][] version 0.2.7 and higher, Ember 1.12.1 and
+higher, and Ember Data v1.13.5.
 
 
 Community

--- a/bower.json
+++ b/bower.json
@@ -1,10 +1,10 @@
 {
   "name": "ember-django-adapter",
   "dependencies": {
-    "ember": "1.12.0",
+    "ember": "1.12.1",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-data": "1.0.0-beta.18",
+    "ember-data": "1.13.5",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.4",
     "ember-qunit": "0.3.3",
     "ember-qunit-notifications": "0.0.7",

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -3,7 +3,7 @@ module.exports = {
     {
       name: 'ember-data-beta',
       dependencies: {
-        'ember-data': '1.0.0-beta.18'
+        'ember-data': '1.13.5'
       }
     },
     {

--- a/docs/non-field-errors.md
+++ b/docs/non-field-errors.md
@@ -1,0 +1,35 @@
+# Non field errors
+
+
+By default, Django REST Framework stores non field errors in a key named 'non_field_errors'
+whenever there is a validation error (HTTP status 400).
+Django REST Framework allows to customize the name of this key.
+
+If you changed the default value, you will need to [extend](extending.md) the adapter and set
+`nonFieldErrorsKey` in `app/adapters/application.js`:
+
+```js
+// app/adapters/application.js
+
+import DRFAdapter from './drf';
+
+export default DRFAdapter.extend({
+  nonFieldErrorKey: 'my_key_name_is_waaay_cooler'
+});
+```
+
+In the case of an InvalidError being raised by the adapter when the response contains non-field errors, the
+adapter will include in the errors array a jsonapi error object of the form:
+
+```js
+{ detail: 'error 1', meta { key: 'non_field_errors' } }  //or whatever key name you configured
+```
+
+In case of several errors, the InvalidError.errors attribute will include
+
+```js
+{ detail: 'error 1', meta { key: 'non_field_errors' } }  //or whatever key name you configured
+{ detail: 'error 2', meta { key: 'non_field_errors' } }  //or whatever key name you configured
+```
+
+     **note** we store the key for non-field errors in a meta object as this is non standard in the error object defined by the jsonapi spec

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -10,7 +10,7 @@ to the server.
 To get a page of records, simply run a find request with the `page` query param:
 
 ```js
-var result = this.store.find("post", {
+var result = this.store.query("post", {
   page: 2
 });
 ```
@@ -51,7 +51,7 @@ to check this condition before using it.
 
 ```js
 if (meta.next) {
-  store.find('post', {page: meta.next})
+  store.query('post', {page: meta.next})
 }
 ```
 
@@ -67,7 +67,7 @@ name that you set in the find request. For example, if you set
  and `page_size` query params. For example:
 
 ```js
-var result = this.store.find("post", {
+var result = this.store.query("post", {
   page: 1,
   page_size: 10
 });

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "ember-cli-pretender": "0.3.2",
     "ember-cli-qunit": "0.3.13",
     "ember-cli-uglify": "^1.0.1",
-    "ember-data": "1.0.0-beta.18",
+    "ember-data": "1.13.5",
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.2",

--- a/tests/acceptance/crud-failure-test.js
+++ b/tests/acceptance/crud-failure-test.js
@@ -27,14 +27,27 @@ module('Acceptance: CRUD Failure', {
       // Server error
       this.get('/test-api/posts/2/', function(request) {
         // This is the default error page for Django when DEBUG is set to False.
-        return [500, {'Content-Type': 'text/html'}, '<h1>Server Error (500)</h1>'];
+        return [500, {'Content-Type': 'application/json'}, JSON.stringify({detail: 'Something bad'})];
       });
+
+      // Authentication Invalid error
+      this.post('/test-api/posts/3', function(request) {
+        return [400, {'Content-Type': 'application/json'}, JSON.stringify({name: 'error 1', non_field_errors: 'error 2'})];
+      });
+
 
       // Create field errors
       this.post('/test-api/posts/', function(request) {
+        var data = JSON.parse(request.requestBody);
+        if (data.body === 'non_field_errors') {
+          return [400, {'Content-Type': 'application/json'}, JSON.stringify({
+            body: ['error 1'],
+            non_field_errors: ['error 2', 'error 3']
+          })];
+        }
         return [400, {'Content-Type': 'application/json'}, JSON.stringify({
           post_title: ['This field is required.'],
-          body: ['This field is required.']
+          body: ['This field is required.', 'This field cannot be blank.']
         })];
       });
 
@@ -67,12 +80,13 @@ test('Permission denied error', function(assert) {
 
   return Ember.run(function() {
 
-    return store.find('post', 1).then({}, function(response) {
+    return store.findRecord('post', 1).then({}, function(response) {
+      const error = response.errors[0];
 
-      assert.ok(response);
-      assert.equal(response.status, 401);
-      assert.equal(response.statusText, 'Unauthorized');
-      assert.equal(response.responseText, JSON.stringify({detail: 'Authentication credentials were not provided.'}));
+      assert.ok(error);
+      assert.equal(error.status, 401);
+      assert.equal(error.detail, 'Authentication credentials were not provided.');
+      assert.equal(response.message, 'Unauthorized');
     });
   });
 });
@@ -82,18 +96,50 @@ test('Server error', function(assert) {
 
   return Ember.run(function() {
 
-    return store.find('post', 2).then({}, function(response) {
+    return store.findRecord('post', 2).then({}, function(response) {
+      const error = response.errors[0];
 
       assert.ok(response);
-      assert.equal(response.status, 500);
-      assert.equal(response.statusText, 'Internal Server Error');
-      assert.equal(response.responseText, '<h1>Server Error (500)</h1>');
+      assert.equal(error.status, 500);
+      assert.equal(error.detail, 'Something bad');
+      assert.equal(response.message, 'Internal Server Error');
+    });
+  });
+});
+
+test('Invalid with non field errors', function(assert) {
+  //assert.expect(8);
+
+  return Ember.run(function() {
+
+    var post = store.createRecord('post', {
+      postTitle: '',
+      body: 'non_field_errors'
+    });
+
+    return post.save().then({}, function(response) {
+      const bodyErrors = post.get('errors.body'),
+            nonFieldErrors1 = response.errors[1],
+            nonFieldErrors2 = response.errors[2];
+      assert.ok(response);
+      assert.ok(response.errors);
+      assert.equal(post.get('isValid'), false);
+
+      assert.equal(bodyErrors.length, 1);
+      assert.equal(bodyErrors[0].message, 'error 1');
+
+      assert.equal(nonFieldErrors1.detail, 'error 2');
+      assert.equal(nonFieldErrors1.meta.key, 'non_field_errors');
+
+      assert.equal(nonFieldErrors2.detail, 'error 3');
+      assert.equal(nonFieldErrors2.meta.key, 'non_field_errors');
+
     });
   });
 });
 
 test('Create field errors', function(assert) {
-  assert.expect(6);
+  assert.expect(8);
 
   return Ember.run(function() {
 
@@ -103,17 +149,20 @@ test('Create field errors', function(assert) {
     });
 
     return post.save().then({}, function(response) {
-
+      const postTitleErrors = post.get('errors.postTitle'),
+            bodyErrors = post.get('errors.body');
       assert.ok(response);
       assert.ok(response.errors);
+      assert.equal(post.get('isValid'), false);
 
       // Test camelCase field.
-      assert.equal(response.errors.postTitle.length, 1);
-      assert.equal(response.errors.postTitle[0], 'This field is required.');
+      assert.equal(postTitleErrors.length, 1);
+      assert.equal(postTitleErrors[0].message, 'This field is required.');
 
       // Test non-camelCase field.
-      assert.equal(response.errors.body.length, 1);
-      assert.equal(response.errors.body[0], 'This field is required.');
+      assert.equal(bodyErrors.length, 2);
+      assert.equal(bodyErrors[0].message, 'This field is required.');
+      assert.equal(bodyErrors[1].message, 'This field cannot be blank.');
     });
   });
 });
@@ -123,8 +172,7 @@ test('Update field errors', function(assert) {
 
   return Ember.run(function() {
 
-    return store.find('post', 3).then(function(post) {
-
+    return store.findRecord('post', 3).then(function(post) {
       assert.ok(post);
       assert.equal(post.get('isDirty'), false);
       post.set('postTitle', 'Lorem ipsum dolor sit amet, consectetur adipiscing el');
@@ -132,17 +180,19 @@ test('Update field errors', function(assert) {
       assert.equal(post.get('isDirty'), true);
 
       post.save().then({}, function(response) {
+        const postTitleErrors = post.get('errors.postTitle'),
+              bodyErrors = post.get('errors.body');
 
         assert.ok(response);
         assert.ok(response.errors);
 
         // Test camelCase field.
-        assert.equal(response.errors.postTitle.length, 1);
-        assert.equal(response.errors.postTitle[0], 'Ensure this value has at most 50 characters (it has 53).');
+        assert.equal(postTitleErrors.length, 1);
+        assert.equal(postTitleErrors[0].message, 'Ensure this value has at most 50 characters (it has 53).');
 
         // Test non-camelCase field.
-        assert.equal(response.errors.body.length, 1);
-        assert.equal(response.errors.body[0], 'This field is required.');
+        assert.equal(bodyErrors.length, 1);
+        assert.equal(bodyErrors[0].message, 'This field is required.');
       });
     });
   });

--- a/tests/acceptance/crud-success-test.js
+++ b/tests/acceptance/crud-success-test.js
@@ -82,7 +82,7 @@ module('Acceptance: CRUD Success', {
 test('Retrieve list of non-paginated records', function(assert) {
   assert.expect(4);
 
-  return store.find('post').then(function(posts) {
+  return store.findAll('post').then(function(posts) {
 
     assert.ok(posts);
     assert.equal(posts.get('length'), 3);
@@ -99,7 +99,7 @@ test('Retrieve single record', function(assert) {
 
   return Ember.run(function() {
 
-    return store.find('post', 1).then(function(post) {
+    return store.findRecord('post', 1).then(function(post) {
 
       assert.ok(post);
       assert.equal(post.get('postTitle'), 'post title 1');
@@ -113,7 +113,7 @@ test('Retrieve via query', function(assert) {
 
   return Ember.run(function() {
 
-    return store.find('post', {post_title: 'post title 2'}).then(function(post) {
+    return store.query('post', {post_title: 'post title 2'}).then(function(post) {
 
       assert.ok(post);
 
@@ -149,7 +149,7 @@ test('Update record', function(assert) {
 
   return Ember.run(function() {
 
-    return store.find('post', 1).then(function(post) {
+    return store.findRecord('post', 1).then(function(post) {
 
       assert.ok(post);
       assert.equal(post.get('isDirty'), false);
@@ -177,7 +177,7 @@ test('Delete record', function(assert) {
 
   return Ember.run(function() {
 
-    return store.find('post', 1).then(function(post) {
+    return store.findRecord('post', 1).then(function(post) {
 
       assert.ok(post);
 

--- a/tests/acceptance/pagination-test.js
+++ b/tests/acceptance/pagination-test.js
@@ -113,7 +113,7 @@ module('Acceptance: Pagination', {
 test('Retrieve list of paginated records', function(assert) {
   assert.expect(8);
 
-  return store.find('post').then(function(response) {
+  return store.findAll('post').then(function(response) {
     assert.ok(response);
 
     assert.equal(response.get('length'), 4);
@@ -138,7 +138,7 @@ test('Retrieve list of paginated records', function(assert) {
 test("Type metadata doesn't have previous", function(assert) {
   assert.expect(5);
 
-  return store.find('post').then(function(response) {
+  return store.findAll('post').then(function(response) {
     assert.ok(response);
 
     // Test the type metadata.
@@ -147,7 +147,7 @@ test("Type metadata doesn't have previous", function(assert) {
     assert.equal(metadata.next, 2);
     assert.equal(metadata.previous, null);
 
-    // No metadata on results when using find without query params.
+    // No metadata on results when using findAll.
     assert.ok(!response.get('meta'));
   });
 });
@@ -156,7 +156,7 @@ test("Type metadata doesn't have previous", function(assert) {
 test("Type metadata doesn't have next", function(assert) {
   assert.expect(8);
 
-  return store.find('post', {page: 2}).then(function(response) {
+  return store.query('post', {page: 2}).then(function(response) {
     assert.ok(response);
     assert.equal(response.get('length'), 2);
 
@@ -178,7 +178,7 @@ test("Type metadata doesn't have next", function(assert) {
 test("Test page_size query param", function(assert) {
   assert.expect(8);
 
-  return store.find('post', {page: 2, page_size: 2}).then(function(response) {
+  return store.query('post', {page: 2, page_size: 2}).then(function(response) {
     assert.ok(response);
     assert.equal(response.get('length'), 2);
 

--- a/tests/acceptance/relationship-links-test.js
+++ b/tests/acceptance/relationship-links-test.js
@@ -85,7 +85,7 @@ test('belongsTo', function(assert) {
 
   return Ember.run(function() {
 
-    return store.find('comment', 2).then(function(comment) {
+    return store.findRecord('comment', 2).then(function(comment) {
 
       assert.ok(comment);
 
@@ -102,7 +102,7 @@ test('hasMany', function(assert) {
 
   return Ember.run(function() {
 
-    return store.find('post', 1).then(function(post) {
+    return store.findRecord('post', 1).then(function(post) {
 
       assert.ok(post);
 

--- a/tests/acceptance/relationships-test.js
+++ b/tests/acceptance/relationships-test.js
@@ -77,7 +77,7 @@ test('belongsTo', function(assert) {
 
   return Ember.run(function() {
 
-    return store.find('comment', 2).then(function(comment) {
+    return store.findRecord('comment', 2).then(function(comment) {
 
       assert.ok(comment);
 
@@ -94,7 +94,7 @@ test('hasMany', function(assert) {
 
   return Ember.run(function() {
 
-    return store.find('post', 1).then(function(post) {
+    return store.findRecord('post', 1).then(function(post) {
 
       assert.ok(post);
 

--- a/tests/unit/adapters/drf-test.js
+++ b/tests/unit/adapters/drf-test.js
@@ -42,46 +42,55 @@ test('buildURL - no trailing slashes', function(assert) {
   assert.equal(adapter.buildURL('FurryAnimals', 5, null), 'test-host/test-api/furry-animals/5');
 });
 
-test('ajaxError - returns invalid error if 400 response', function(assert) {
-  var error = new DS.InvalidError({errors: {name: ['This field cannot be blank.']}});
-
-  var jqXHR = {
-    status: 400,
-    responseText: JSON.stringify({name: ['This field cannot be blank.']})
-  };
+test('handleResponse - returns invalid error if 400 response', function(assert) {
+  const headers = {},
+        status = 400,
+        payload = {
+          name: ['This field cannot be blank.'],
+          post_title: ['This field cannot be blank.', 'This field cannot be empty.']
+        };
 
   var adapter = this.subject();
-  assert.equal(adapter.ajaxError(jqXHR), error.toString());
+  var error = adapter.handleResponse(status, headers, payload);
+  assert.equal(error.errors[0].detail, 'This field cannot be blank.');
+  assert.equal(error.errors[0].source.pointer, 'data/attributes/name');
+  assert.equal(error.errors[0].title, 'Invalid Attribute');
+
+  assert.equal(error.errors[1].detail, 'This field cannot be blank.');
+  assert.equal(error.errors[1].source.pointer, 'data/attributes/post_title');
+  assert.equal(error.errors[1].title, 'Invalid Attribute');
+
+  assert.equal(error.errors[2].detail, 'This field cannot be empty.');
+  assert.equal(error.errors[2].source.pointer, 'data/attributes/post_title');
+  assert.equal(error.errors[2].title, 'Invalid Attribute');
 });
 
-test('ajaxError - returns error if not 400 response', function(assert) {
-  var jqXHR = {
-    status: 403,
-    responseText: JSON.stringify({detail: 'You do not have permission to perform this action.'})
-  };
-
-  var adapter = this.subject();
-  assert.equal(adapter.ajaxError(jqXHR), jqXHR);
+test('handleResponse - returns error if not 400 response', function(assert) {
+  const headers = {},
+        status = 403,
+        payload = { detail: 'You do not have permission to perform this action.'},
+        adapter = this.subject();
+  var error = adapter.handleResponse(status, headers, payload);
+  assert.equal(error.errors[0].detail, payload.detail);
 });
 
-test('ajaxError - returns error if no responseText to parse', function(assert) {
-  var jqXHR = {
-    status: 500,
-    statusText: 'Internal Server Error',
-    responseText: ''
-  };
-
-  var adapter = this.subject();
-  assert.equal(adapter.ajaxError(jqXHR), jqXHR);
+test('handleResponse - returns error if payload is empty', function(assert) {
+  const headers = {},
+        status = 409,
+        payload = {},
+        adapter = this.subject();
+  var error = adapter.handleResponse(status, headers, payload);
+  assert.equal(error.errors[0].detail, '');
 });
 
-test('ajaxError - returns ajax response if no status returned', function(assert) {
-  var jqXHR = {
-    responseText: 'Something went wrong'
-  };
-
-  var adapter = this.subject();
-  assert.equal(adapter.ajaxError(jqXHR), jqXHR);
+test('handleResponse - returns error with internal server error if 500', function(assert) {
+  const headers = {},
+        status = 500,
+        payload = {},
+        adapter = this.subject();
+  var error = adapter.handleResponse(status, headers, payload);
+  assert.equal(error.errors[0].detail, '');
+  assert.equal(error.message, 'Internal Server Error');
 });
 
 test('_stripIDFromURL - returns base URL for type', function(assert) {


### PR DESCRIPTION
@dustinfarris @benkonrath I tested this in a project of mine and it that work ok for me, but if would be great if you guys can test it in your projects before merge.

Something I doesn't quite like is how I handle the non_field_errors case where I need to stick the key in the meta field as there is no sensible place to put it in a Jsonapi error object.

    - Not tested with older ED versions as we won't support beta versions
    - Ember 1.12.1 or later is needed from now on

Closes #103