### PR TITLE
Update to ember 1.13 serializer api.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ ember-django-adapter Changelog
 
 Master
 ------
+* [BREAKING ENHANCEMENT] Update to new Ember 1.13 serializer API
+  ([#114](https://github.com/dustinfarris/ember-django-adapter/pull/114))
 * [ENHANCEMENT] Add support for HyperlinkedRelatedFields.
 * [INTERNAL] Updated ember-cli version to latest (1.13.1)
 * [ENHANCEMENT] Adapter now supports ember-data 1.13.5

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ various backend APIs.
 
 This adapter enables the use of [Django REST Framework][] as an API backend for
 Ember Data.  The addon is compatible with [ember-cli][] version 0.2.7 and higher, Ember 1.12.1 and
-higher, and Ember Data v1.13.5.
+higher, and Ember Data v1.13.6.
 
 
 Community

--- a/bower.json
+++ b/bower.json
@@ -1,10 +1,10 @@
 {
   "name": "ember-django-adapter",
   "dependencies": {
-    "ember": "1.13.4",
+    "ember": "1.13.5",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-data": "1.13.5",
+    "ember-data": "1.13.6",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
     "ember-qunit": "0.4.1",
     "ember-qunit-notifications": "0.0.7",

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -3,15 +3,15 @@ module.exports = {
     {
       name: 'ember-data-113-ember-112',
       dependencies: {
-        'ember-data': '1.13.5',
+        'ember-data': '1.13.6',
         'ember': '1.12.1'
       }
     },
     {
       name: 'ember-data-113-ember-113',
       dependencies: {
-        'ember-data': '1.13.5',
-        'ember': '1.13.4'
+        'ember-data': '1.13.6',
+        'ember': '1.13.5'
       }
     }
   ]

--- a/docs/coalesce-find-requests.md
+++ b/docs/coalesce-find-requests.md
@@ -3,7 +3,7 @@
 When a record returns the IDs of records in a hasMany relationship, Ember Data
 allows us to opt-in to combine these requests into a single request.
 
-*Note:* Using [hyperlinked related fields](hyperlinked-related-fields.md) to retrieve related
+**Note:** Using [hyperlinked related fields](hyperlinked-related-fields.md) to retrieve related
 records in a single request is preferred over using coalesceFindRequests since there is a limit on
 the number of records per request on read-only fields due to URL length restrictions. 
 

--- a/docs/hyperlinked-related-fields.md
+++ b/docs/hyperlinked-related-fields.md
@@ -43,7 +43,7 @@ related comments instead of one URL per related record:
 }
 ```
 
-*Note:* It is also possible to use the [Coalesce Find Requests](coalesce-find-requests.md)
+**Note:** It is also possible to use the [Coalesce Find Requests](coalesce-find-requests.md)
 feature to retrieve related records in a single request, however, this is the preferred
 solution.
 

--- a/docs/non-field-errors.md
+++ b/docs/non-field-errors.md
@@ -32,4 +32,5 @@ In case of several errors, the InvalidError.errors attribute will include
 { detail: 'error 2', meta { key: 'non_field_errors' } }  //or whatever key name you configured
 ```
 
-     **note** we store the key for non-field errors in a meta object as this is non standard in the error object defined by the jsonapi spec
+**Note:** We store the key for non-field errors in a meta object as this is non standard in the error
+object defined by the JSON API spec.

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -4,147 +4,107 @@ Pagination is supported using the metadata support that is built into Ember Data
 Metadata from Django REST Framework paginated list views is updated on every request
 to the server.
 
+The pagination support in EDA works with the default pagination setup in DRF 3.0 and the
+[PageNumberPagination](http://www.django-rest-framework.org/api-guide/pagination/#pagenumberpagination)
+class in DRF 3.1. It's possible to use the other DRF 3.1 pagination classes by
+overriding `extractMeta` (see [customizing the Metadata](#customizing-the-metadata) below).
 
-## Retrieving the Metadata
 
-To get a page of records, simply run a find request with the `page` query param:
+## Accessing the Metadata
 
-```js
-var result = this.store.query("post", {
-  page: 2
-});
-```
-
-After the request returns, you can access the metadata either with `store.metadataFor`:
+To get a page of records, simply run a `query` request with the `page` query param.
 
 ```js
-var meta = this.store.metadataFor("post");
+let result = this.store.query('post', {page: 1});
 ```
 
-Or you can access the metadata just for this query:
+All of the DRF metadata (including the pagination metadata) can be access through the
+`meta` property of the result once the promise is fulfilled.
 
 ```js
-var meta = result.get("content.meta");
+let meta = result.get('meta');
 ```
 
-**NB** Running a find request against a paginated list view without query params will
-retrieve the first page with metadata set in only `store.metadataFor`. This is how
-metadata works in Ember Data.
+**Note:** The `meta` property will only be set on results of `query` requests.
 
 
-## Metadata Properties
+## Pagination Metadata
 
-The metadata consists of three properties that give the application enough information
-to paginate through a Django REST Framework paginated list view.
+The pagination metadata consists of three properties that give the application enough
+information to paginate through a Django REST Framework paginated list view.
 
 * `next` - The next page number or `null` when there is no next page (i.e. the last
            page).
 * `previous` - The previous page number or `null` when there is no previous page (i.e.
                the first page).
 * `count` - The total number of records available. This can be used along with the page
-            size to calculate the total number of pages.
+            size to calculate the total number of pages (see
+            [customizing the Metadata](#customizing-the-metadata) below).
 
 
 The `next` and `previous` page number can be used directly as the value of the `page`
 query param. `null` is not a valid value for the `page` query param so applications need
-to check this condition before using it.
+to check if `next` and `previous` are null before using them.
 
 ```js
 if (meta.next) {
-  store.query('post', {page: meta.next})
+  result = store.query('post', {page: meta.next})
 }
 ```
 
-## Django REST Framework settings
+## Customizing the Metadata
 
-Django REST Framework has a number of settings that can be used to customise the
-pagination behaviour of generic views.
-
-One useful setting is `PAGINATE_BY_PARAM` / `paginate_by_param`. If this is enabled,
-it's possible to override the server-side page size by including the query param
-name that you set in the find request. For example, if you set
-`PAGINATE_BY_PARAM = 'page_size'`, you would run the find request with the `page`
- and `page_size` query params. For example:
+You can customize the metadata by overriding the `extractMeta` and adding and / or removing
+metadata as indicated in this template.
 
 ```js
-var result = this.store.query("post", {
-  page: 1,
-  page_size: 10
-});
-```
+// app/serializer/<model>.js
 
-If you use the `PAGINATE_BY_PARAM` or `paginate_by_param` setting, it's advisable to also
-set `MAX_PAGINATE_BY`.
-
-These global settings serve as a good starting point for your Django REST Framework pagination configuration:
-
-```Python
-REST_FRAMEWORK = {
-    'PAGINATE_BY': 10,                 # Default to 10
-    'PAGINATE_BY_PARAM': 'page_size',  # Allow client to override, using `?page_size=xxx`.
-    'MAX_PAGINATE_BY': 100             # Maximum limit allowed when using `?page_size=xxx`.
-}
-```
-
-The complete pagination configuration documentation is available in Django REST Framework docs.
-
-[http://www.django-rest-framework.org/api-guide/pagination/#pagination-in-the-generic-views](http://www.django-rest-framework.org/api-guide/pagination/#pagination-in-the-generic-views)
-
-
-## Integration with 3rd Party Libraries
-
-* Ember CLI Pagination
-
-[https://github.com/mharris717/ember-cli-pagination](https://github.com/mharris717/ember-cli-pagination)
-
-Add a total_pages key in API response by making a CustomPageNumberPagination class
-```python
-REST_FRAMEWORK = {
-  'DEFAULT_PAGINATION_CLASS': 'utils.pagination.CustomPageNumberPagination'
-}
-```
-
-```python
-# utils/pagination.py
-from rest_framework.compat import OrderedDict
-from rest_framework.pagination import PageNumberPagination
-from rest_framework.response import Response
-
-class CustomPageNumberPagination(PageNumberPagination):
-    def get_paginated_response(self, data):
-        return Response(OrderedDict([
-            ('total_pages', self.page.paginator.num_pages),
-            ('count', self.page.paginator.count),
-            ('next', self.get_next_link()),
-            ('previous', self.get_previous_link()),
-            ('results', data)
-        ]))
-```
-
-Then override ```extractMeta``` function of the DRFSerializer in your model serializer
-
-```js
-//app/serializer/post.js
+import Ember from 'ember';
 import DRFSerializer from './drf';
-import DS from 'ember-data';
 
-export default DRFSerializer.extend(DS.EmbeddedRecordsMixin, {
-    extractMeta: function(store, type, payload) {
-        if (payload && payload.results) {
-          // Sets the metadata for the type.
-          store.setMetadataFor(type, {
-            count: payload.count,
-            next: this.extractPageNumber(payload.next),
-            previous: this.extractPageNumber(payload.previous),
-            total_pages: payload.total_pages
-          });
+export default DRFSerializer.extend({
+  extractMeta: function(store, type, payload) {
+    let meta = this._super(store, type, payload);
+    if (!Ember.isNone(meta)) {
 
-          // Keep ember data from trying to parse the metadata as a records
-          delete payload.count;
-          delete payload.next;
-          delete payload.previous;
-          delete payload.total_pages;
-        }
-    },
+      // Add or remove metadata here.
+
+    }
+    return meta;
+  }
 });
 ```
+
+This version of `extractMeta` adds the total page count to the `post` metadata.
+
+```js
+// app/serializer/post.js
+
+import Ember from 'ember';
+import DRFSerializer from './drf';
+
+export default DRFSerializer.extend({
+  extractMeta: function(store, type, payload) {
+    let meta = this._super(store, type, payload);
+    if (!Ember.isNone(meta)) {
+      // Add totalPages to metadata.
+      let totalPages = 1;
+      if (!Ember.isNone(meta.next)) {
+        // Any page that is not the last page.
+        totalPages = Math.ceil(meta.count / payload.results.length);
+      } else if (Ember.isNone(meta.next) && !Ember.isNone(meta.previous)) {
+        // The last page when there is more than one page.
+        totalPages = meta.previous + 1;
+      }
+      meta['totalPages'] = totalPages;
+    }
+    return meta;
+  }
+});
+```
+
+If you don't use the `PageNumberPagination` for pagination with DRF 3.1 you can also add
+the metadata for the pagination scheme you use here. We may add support for the other
+pagination classes in the future. If this is something you are interested in contributing,
+please file an issue on github.

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "ember-cli-qunit": "0.3.15",
     "ember-cli-release": "0.2.3",
     "ember-cli-uglify": "^1.0.1",
-    "ember-data": "1.13.5",
+    "ember-data": "1.13.6",
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.2",

--- a/tests/acceptance/crud-failure-test.js
+++ b/tests/acceptance/crud-failure-test.js
@@ -15,7 +15,7 @@ module('Acceptance: CRUD Failure', {
   beforeEach: function() {
     application = startApp();
 
-    store = application.__container__.lookup('store:main');
+    store = application.__container__.lookup('service:store');
 
     server = new Pretender(function() {
 
@@ -174,10 +174,10 @@ test('Update field errors', function(assert) {
 
     return store.findRecord('post', 3).then(function(post) {
       assert.ok(post);
-      assert.equal(post.get('isDirty'), false);
+      assert.equal(post.get('hasDirtyAttributes'), false);
       post.set('postTitle', 'Lorem ipsum dolor sit amet, consectetur adipiscing el');
       post.set('body', '');
-      assert.equal(post.get('isDirty'), true);
+      assert.equal(post.get('hasDirtyAttributes'), true);
 
       post.save().then({}, function(response) {
         const postTitleErrors = post.get('errors.postTitle'),

--- a/tests/acceptance/crud-success-test.js
+++ b/tests/acceptance/crud-success-test.js
@@ -35,7 +35,7 @@ module('Acceptance: CRUD Success', {
   beforeEach: function() {
     application = startApp();
 
-    store = application.__container__.lookup('store:main');
+    store = application.__container__.lookup('service:store');
 
     server = new Pretender(function() {
 
@@ -156,18 +156,18 @@ test('Update record', function(assert) {
     return store.findRecord('post', 1).then(function(post) {
 
       assert.ok(post);
-      assert.equal(post.get('isDirty'), false);
+      assert.equal(post.get('hasDirtyAttributes'), false);
 
       return Ember.run(function() {
 
         post.set('postTitle', 'new post title');
         post.set('body', 'new post body');
-        assert.equal(post.get('isDirty'), true);
+        assert.equal(post.get('hasDirtyAttributes'), true);
 
         return post.save().then(function(post) {
 
           assert.ok(post);
-          assert.equal(post.get('isDirty'), false);
+          assert.equal(post.get('hasDirtyAttributes'), false);
           assert.equal(post.get('postTitle'), 'new post title');
           assert.equal(post.get('body'), 'new post body');
         });

--- a/tests/acceptance/embedded-records-test.js
+++ b/tests/acceptance/embedded-records-test.js
@@ -17,16 +17,16 @@ var embeddedCommentsPosts = [
     body: 'post body 1',
     comments: [
       {
-        id: 1,
-        body: 'comment body 1'
-      },
-      {
         id: 2,
         body: 'comment body 2'
       },
       {
         id: 3,
         body: 'comment body 3'
+      },
+      {
+        id: 4,
+        body: 'comment body 4'
       }
     ]
   }
@@ -34,21 +34,21 @@ var embeddedCommentsPosts = [
 
 var embeddedPostComments = [
   {
-    id: 1,
-    body: 'comment body 1',
+    id: 5,
+    body: 'comment body 5',
     post: {
-      id: 1,
-      post_title: 'post title 1',
-      body: 'post body 1'
+      id: 6,
+      post_title: 'post title 6',
+      body: 'post body 6'
     }
   }
 ];
 
 var posts = [
   {
-    id: 2,
-    post_title: 'post title 2',
-    body: 'post body 2',
+    id: 7,
+    post_title: 'post title 7',
+    body: 'post body 7',
     comments: []
   }
 ];
@@ -65,17 +65,17 @@ module('Acceptance: Embedded Records', {
         return [200, {'Content-Type': 'application/json'}, JSON.stringify(embeddedCommentsPosts[0])];
       });
 
-      this.get('/test-api/embedded-post-comments/1/', function() {
+      this.get('/test-api/embedded-post-comments/5/', function() {
         return [200, {'Content-Type': 'application/json'}, JSON.stringify(embeddedPostComments[0])];
       });
 
-      this.get('/test-api/posts/2/', function() {
+      this.get('/test-api/posts/7/', function() {
         return [200, {'Content-Type': 'application/json'}, JSON.stringify(posts[0])];
       });
 
       this.post('/test-api/embedded-post-comments/', function(request) {
         let data = Ember.$.parseJSON(request.requestBody);
-        data['id'] = 2;
+        data['id'] = 8;
         data['post'] = posts[0];
         return [201, {'Content-Type': 'application/json'}, JSON.stringify(data)];
       });
@@ -90,46 +90,58 @@ module('Acceptance: Embedded Records', {
 });
 
 test('belongsTo retrieve', function(assert) {
-  assert.expect(2);
+  assert.expect(6);
 
   return Ember.run(function() {
 
-    return store.findRecord('embedded-post-comment', 1).then(function(comment) {
-
+    return store.findRecord('embedded-post-comment', 5).then(function(comment) {
       assert.ok(comment);
-      assert.ok(comment.get('post'));
+      assert.equal(comment.get('body'), 'comment body 5');
+
+      let post = comment.get('post');
+      assert.ok(post);
+      assert.equal(post.get('postTitle'), 'post title 6');
+      assert.equal(post.get('body'), 'post body 6');
+
+      assert.equal(server.handledRequests.length, 1);
     });
   });
 });
 
 test('hasMany retrieve', function(assert) {
-  assert.expect(6);
+  assert.expect(12);
 
   return Ember.run(function() {
 
     return store.findRecord('embedded-comments-post', 1).then(function(post) {
-
       assert.ok(post);
+      assert.equal(post.get('postTitle'), 'post title 1');
+      assert.equal(post.get('body'), 'post body 1');
 
       let comments = post.get('comments');
       assert.ok(comments);
       assert.equal(comments.get('length'), 3);
       assert.ok(comments.objectAt(0));
+      assert.equal(comments.objectAt(0).get('body'), 'comment body 2');
       assert.ok(comments.objectAt(1));
+      assert.equal(comments.objectAt(1).get('body'), 'comment body 3');
       assert.ok(comments.objectAt(2));
+      assert.equal(comments.objectAt(2).get('body'), 'comment body 4');
+
+      assert.equal(server.handledRequests.length, 1);
     });
   });
 });
 
 test('belongsTo create', function(assert) {
-  assert.expect(5);
+  assert.expect(6);
 
   return Ember.run(function() {
 
-    return store.findRecord('post', 2).then(function(post) {
+    return store.findRecord('post', 7).then(function(post) {
 
       let comment = store.createRecord('embedded-post-comment', {
-        body: 'comment body 2',
+        body: 'comment body 9',
         post: post
       });
 
@@ -137,12 +149,12 @@ test('belongsTo create', function(assert) {
 
         assert.ok(comment);
         assert.ok(comment.get('id'));
-        assert.equal(comment.get('body'), 'comment body 2');
+        assert.equal(comment.get('body'), 'comment body 9');
         assert.ok(comment.get('post'));
 
+        assert.equal(server.handledRequests.length, 2);
         let requestBody = (JSON.parse(server.handledRequests.pop().requestBody));
-        assert.equal(requestBody.post, 2);
-
+        assert.equal(requestBody.post, 7);
       });
     });
   });

--- a/tests/acceptance/pagination-test.js
+++ b/tests/acceptance/pagination-test.js
@@ -53,7 +53,7 @@ module('Acceptance: Pagination', {
   beforeEach: function() {
     application = startApp();
 
-    store = application.__container__.lookup('store:main');
+    store = application.__container__.lookup('service:store');
 
     // The implementation of the paginated Pretender server is dynamic
     // so it can be used with all of the pagination tests. Otherwise,
@@ -111,9 +111,9 @@ module('Acceptance: Pagination', {
 });
 
 test('Retrieve list of paginated records', function(assert) {
-  assert.expect(8);
+  assert.expect(7);
 
-  return store.findAll('post').then(function(response) {
+  return store.query('post', {page: 1}).then(function(response) {
     assert.ok(response);
 
     assert.equal(response.get('length'), 4);
@@ -123,75 +123,53 @@ test('Retrieve list of paginated records', function(assert) {
     assert.equal(post.get('postTitle'), 'post title 2');
     assert.equal(post.get('body'), 'post body 2');
 
-    // Test the type metadata.
-    var metadata = store.metadataFor('post');
+    var metadata = response.get('meta');
     assert.equal(metadata.count, 6);
     assert.equal(metadata.next, 2);
     assert.equal(metadata.previous, null);
-
-    // No metadata on results when using find without query params.
-    assert.ok(!response.get('meta'));
   });
 });
 
 
 test("Type metadata doesn't have previous", function(assert) {
-  assert.expect(5);
+  assert.expect(4);
 
-  return store.findAll('post').then(function(response) {
+  return store.query('post', {page: 1}).then(function(response) {
     assert.ok(response);
 
-    // Test the type metadata.
-    var metadata = store.metadataFor('post');
+    var metadata = response.get('meta');
     assert.equal(metadata.count, 6);
     assert.equal(metadata.next, 2);
     assert.equal(metadata.previous, null);
-
-    // No metadata on results when using findAll.
-    assert.ok(!response.get('meta'));
   });
 });
 
 
 test("Type metadata doesn't have next", function(assert) {
-  assert.expect(8);
+  assert.expect(5);
 
   return store.query('post', {page: 2}).then(function(response) {
     assert.ok(response);
     assert.equal(response.get('length'), 2);
 
-    // Test the type metadata.
-    var typeMetadata = store.metadataFor('post');
-    assert.equal(typeMetadata.count, 6);
-    assert.equal(typeMetadata.next, null);
-    assert.equal(typeMetadata.previous, 1);
-
-    // Test the results metadata.
-    var resultsMetadata = response.get('meta');
-    assert.equal(resultsMetadata.count, 6);
-    assert.equal(resultsMetadata.next, null);
-    assert.equal(resultsMetadata.previous, 1);
+    var metadata = response.get('meta');
+    assert.equal(metadata.count, 6);
+    assert.equal(metadata.next, null);
+    assert.equal(metadata.previous, 1);
   });
 });
 
 
 test("Test page_size query param", function(assert) {
-  assert.expect(8);
+  assert.expect(5);
 
   return store.query('post', {page: 2, page_size: 2}).then(function(response) {
     assert.ok(response);
     assert.equal(response.get('length'), 2);
 
-    // Test the type metadata.
-    var typeMetadata = store.metadataFor('post');
-    assert.equal(typeMetadata.count, 6);
-    assert.equal(typeMetadata.previous, 1);
-    assert.equal(typeMetadata.next, 3);
-
-    // Test the results metadata.
-    var resultsMetadata = response.get('meta');
-    assert.equal(resultsMetadata.count, 6);
-    assert.equal(resultsMetadata.previous, 1);
-    assert.equal(resultsMetadata.next, 3);
+    var metadata = response.get('meta');
+    assert.equal(metadata.count, 6);
+    assert.equal(metadata.previous, 1);
+    assert.equal(metadata.next, 3);
   });
 });

--- a/tests/acceptance/relationship-links-test.js
+++ b/tests/acceptance/relationship-links-test.js
@@ -48,12 +48,11 @@ var comments = [
   }
 ];
 
-
 module('Acceptance: Relationship Links', {
   beforeEach: function() {
     application = startApp();
 
-    store = application.__container__.lookup('store:main');
+    store = application.__container__.lookup('service:store');
 
     server = new Pretender(function() {
       this.get('/test-api/posts/:id/', function(request) {
@@ -95,7 +94,6 @@ test('belongsTo', function(assert) {
     });
   });
 });
-
 
 test('hasMany', function(assert) {
   assert.expect(9);

--- a/tests/acceptance/relationships-test.js
+++ b/tests/acceptance/relationships-test.js
@@ -52,7 +52,7 @@ module('Acceptance: Relationships', {
   beforeEach: function() {
     application = startApp();
 
-    store = application.__container__.lookup('store:main');
+    store = application.__container__.lookup('service:store');
 
     server = new Pretender(function() {
 
@@ -87,7 +87,6 @@ test('belongsTo', function(assert) {
     });
   });
 });
-
 
 test('hasMany', function(assert) {
   assert.expect(6);


### PR DESCRIPTION
I still need to update the documentation.

There is one remaining deprecation warning but it is an application level warning so I don't think we should override this function in EDA.
```
DEPRECATION: The default behavior of shouldReloadAll will change in Ember Data 2.0 to always return false when there is at least one "post" record in the store. If you would like to preserve the current behavior please override shouldReloadAll in your adapter:application and return true.
```

closes #110
closes #111