### PR TITLE
Add acceptance test for embedded records.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-django-adapter",
   "dependencies": {
-    "ember": "1.13.3",
+    "ember": "1.13.4",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
     "ember-data": "1.13.5",

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,15 +1,17 @@
 module.exports = {
   scenarios: [
     {
-      name: 'ember-data-stable',
+      name: 'ember-data-113-ember-112',
       dependencies: {
-        'ember-data': '1.13.5'
+        'ember-data': '1.13.5',
+        'ember': '1.12.1'
       }
     },
     {
-      name: 'ember-data-canary',
+      name: 'ember-data-113-ember-113',
       dependencies: {
-        'ember-data': 'canary'
+        'ember-data': '1.13.5',
+        'ember': '1.13.4'
       }
     }
   ]

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "start": "ember server",
     "build": "ember build",
-    "test": "ember try ember-data-stable"
+    "test": "ember try:testall"
   },
   "repository": "https://github.com/dustinfarris/ember-django-adapter",
   "engines": {

--- a/tests/acceptance/embedded-records-test.js
+++ b/tests/acceptance/embedded-records-test.js
@@ -1,0 +1,105 @@
+import Ember from 'ember';
+import {
+  module,
+  test
+} from 'qunit';
+import Pretender from 'pretender';
+import startApp from 'dummy/tests/helpers/start-app';
+
+var application;
+var store;
+var server;
+
+var embeddedCommentsPosts = [
+  {
+    id: 1,
+    post_title: 'post title 1',
+    body: 'post body 1',
+    comments: [
+      {
+        id: 1,
+        body: 'comment body 1'
+      },
+      {
+        id: 2,
+        body: 'comment body 2'
+      },
+      {
+        id: 3,
+        body: 'comment body 3'
+      }
+    ]
+  }
+];
+
+var embeddedPostComments = [
+  {
+    id: 1,
+    body: 'comment body 1',
+    post: {
+      id: 1,
+      post_title: 'post title 1',
+      body: 'post body 1'
+    }
+  }
+];
+
+module('Acceptance: Embedded Records', {
+  beforeEach: function() {
+    application = startApp();
+
+    store = application.__container__.lookup('service:store');
+
+    server = new Pretender(function() {
+
+      this.get('/test-api/embedded-comments-posts/:id/', function(request) {
+        return [200, {'Content-Type': 'application/json'}, JSON.stringify(embeddedCommentsPosts[request.params.id - 1])];
+      });
+
+      this.get('/test-api/embedded-post-comments/:id/', function(request) {
+        return [200, {'Content-Type': 'application/json'}, JSON.stringify(embeddedPostComments[request.params.id - 1])];
+      });
+    });
+  },
+
+  afterEach: function() {
+    Ember.run(application, 'destroy');
+    server.shutdown();
+  }
+});
+
+test('belongsTo', function(assert) {
+  assert.expect(2);
+
+  return Ember.run(function() {
+
+    return store.findRecord('embedded-post-comment', 1).then(function(comment) {
+
+      assert.ok(comment);
+
+      return comment.get('post').then(function(post) {
+        assert.ok(post);
+      });
+    });
+  });
+});
+
+test('hasMany', function(assert) {
+  assert.expect(6);
+
+  return Ember.run(function() {
+
+    return store.findRecord('embedded-comments-post', 1).then(function(post) {
+
+      assert.ok(post);
+
+      return post.get('comments').then(function(comments) {
+        assert.ok(comments);
+        assert.equal(comments.get('length'), 3);
+        assert.ok(comments.objectAt(0));
+        assert.ok(comments.objectAt(1));
+        assert.ok(comments.objectAt(2));
+      });
+    });
+  });
+});

--- a/tests/dummy/app/models/embedded-comments-post.js
+++ b/tests/dummy/app/models/embedded-comments-post.js
@@ -1,0 +1,7 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  postTitle: DS.attr(),
+  body: DS.attr(),
+  comments: DS.hasMany('comment', {async: true})
+});

--- a/tests/dummy/app/models/embedded-post-comment.js
+++ b/tests/dummy/app/models/embedded-post-comment.js
@@ -1,0 +1,6 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  body: DS.attr(),
+  post: DS.belongsTo('post', {async: true})
+});

--- a/tests/dummy/app/serializers/embedded-comments-post.js
+++ b/tests/dummy/app/serializers/embedded-comments-post.js
@@ -1,0 +1,8 @@
+import DRFSerializer from './drf';
+import DS from 'ember-data';
+
+export default DRFSerializer.extend(DS.EmbeddedRecordsMixin, {
+  attrs: {
+    comments: {embedded: 'always'}
+  }
+});

--- a/tests/dummy/app/serializers/embedded-post-comment.js
+++ b/tests/dummy/app/serializers/embedded-post-comment.js
@@ -1,0 +1,8 @@
+import DRFSerializer from './drf';
+import DS from 'ember-data';
+
+export default DRFSerializer.extend(DS.EmbeddedRecordsMixin, {
+  attrs: {
+    post: {embedded: 'always'}
+  }
+});


### PR DESCRIPTION
This avoids having to manually test the embedded records feature as we update to new ED versions. This test passes on master but fails with #114 which what I expect. 

I also updated the ember-try config to test with E 1.13 / ED 1.13 and E 1.12 / ED 1.13. These are the versions we have listed as supported so it makes sense to test against them.