### PR TITLE
Add a test for embedded belongsTo create with id.

### DIFF
--- a/tests/acceptance/embedded-records-test.js
+++ b/tests/acceptance/embedded-records-test.js
@@ -44,6 +44,15 @@ var embeddedPostComments = [
   }
 ];
 
+var posts = [
+  {
+    id: 2,
+    post_title: 'post title 2',
+    body: 'post body 2',
+    comments: []
+  }
+];
+
 module('Acceptance: Embedded Records', {
   beforeEach: function() {
     application = startApp();
@@ -52,13 +61,25 @@ module('Acceptance: Embedded Records', {
 
     server = new Pretender(function() {
 
-      this.get('/test-api/embedded-comments-posts/:id/', function(request) {
-        return [200, {'Content-Type': 'application/json'}, JSON.stringify(embeddedCommentsPosts[request.params.id - 1])];
+      this.get('/test-api/embedded-comments-posts/1/', function( ) {
+        return [200, {'Content-Type': 'application/json'}, JSON.stringify(embeddedCommentsPosts[0])];
       });
 
-      this.get('/test-api/embedded-post-comments/:id/', function(request) {
-        return [200, {'Content-Type': 'application/json'}, JSON.stringify(embeddedPostComments[request.params.id - 1])];
+      this.get('/test-api/embedded-post-comments/1/', function() {
+        return [200, {'Content-Type': 'application/json'}, JSON.stringify(embeddedPostComments[0])];
       });
+
+      this.get('/test-api/posts/2/', function() {
+        return [200, {'Content-Type': 'application/json'}, JSON.stringify(posts[0])];
+      });
+
+      this.post('/test-api/embedded-post-comments/', function(request) {
+        let data = Ember.$.parseJSON(request.requestBody);
+        data['id'] = 2;
+        data['post'] = posts[0];
+        return [201, {'Content-Type': 'application/json'}, JSON.stringify(data)];
+      });
+
     });
   },
 
@@ -68,7 +89,7 @@ module('Acceptance: Embedded Records', {
   }
 });
 
-test('belongsTo', function(assert) {
+test('belongsTo retrieve', function(assert) {
   assert.expect(2);
 
   return Ember.run(function() {
@@ -76,15 +97,12 @@ test('belongsTo', function(assert) {
     return store.findRecord('embedded-post-comment', 1).then(function(comment) {
 
       assert.ok(comment);
-
-      return comment.get('post').then(function(post) {
-        assert.ok(post);
-      });
+      assert.ok(comment.get('post'));
     });
   });
 });
 
-test('hasMany', function(assert) {
+test('hasMany retrieve', function(assert) {
   assert.expect(6);
 
   return Ember.run(function() {
@@ -93,12 +111,38 @@ test('hasMany', function(assert) {
 
       assert.ok(post);
 
-      return post.get('comments').then(function(comments) {
-        assert.ok(comments);
-        assert.equal(comments.get('length'), 3);
-        assert.ok(comments.objectAt(0));
-        assert.ok(comments.objectAt(1));
-        assert.ok(comments.objectAt(2));
+      let comments = post.get('comments');
+      assert.ok(comments);
+      assert.equal(comments.get('length'), 3);
+      assert.ok(comments.objectAt(0));
+      assert.ok(comments.objectAt(1));
+      assert.ok(comments.objectAt(2));
+    });
+  });
+});
+
+test('belongsTo create', function(assert) {
+  assert.expect(5);
+
+  return Ember.run(function() {
+
+    return store.findRecord('post', 2).then(function(post) {
+
+      let comment = store.createRecord('embedded-post-comment', {
+        body: 'comment body 2',
+        post: post
+      });
+
+      return comment.save().then(function(comment) {
+
+        assert.ok(comment);
+        assert.ok(comment.get('id'));
+        assert.equal(comment.get('body'), 'comment body 2');
+        assert.ok(comment.get('post'));
+
+        let requestBody = (JSON.parse(server.handledRequests.pop().requestBody));
+        assert.equal(requestBody.post, 2);
+
       });
     });
   });

--- a/tests/dummy/app/models/embedded-comments-post.js
+++ b/tests/dummy/app/models/embedded-comments-post.js
@@ -3,5 +3,5 @@ import DS from 'ember-data';
 export default DS.Model.extend({
   postTitle: DS.attr(),
   body: DS.attr(),
-  comments: DS.hasMany('comment', {async: true})
+  comments: DS.hasMany('comment', {async: false})
 });

--- a/tests/dummy/app/models/embedded-post-comment.js
+++ b/tests/dummy/app/models/embedded-post-comment.js
@@ -2,5 +2,5 @@ import DS from 'ember-data';
 
 export default DS.Model.extend({
   body: DS.attr(),
-  post: DS.belongsTo('post', {async: true})
+  post: DS.belongsTo('post', {async: false})
 });

--- a/tests/dummy/app/serializers/embedded-post-comment.js
+++ b/tests/dummy/app/serializers/embedded-post-comment.js
@@ -3,6 +3,6 @@ import DS from 'ember-data';
 
 export default DRFSerializer.extend(DS.EmbeddedRecordsMixin, {
   attrs: {
-    post: {embedded: 'always'}
+    post: {serialize: 'id', deserialize: 'records'}
   }
 });


### PR DESCRIPTION
Ids for embedded beolongsTo aren't being sent when creating a record. My interpretation is that setting `post: {serialize: 'id', deserialize: 'records'}` in the serializer should allow the embedded record to work on retrieve but also allow the id to be set on create / update. The test shows that ED is sending `null` instead of the id.

I've included a couple of other cleanups / fixes in the PR. The `belongsTo create` is the relevant test. Any thoughts here?