### PR TITLE
Implement normalizeQueryRecordResponse

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -28,5 +28,5 @@
   "white": false,
   "eqnull": true,
   "esnext": true,
-  "unused": true
+  "unused": "vars"
 }

--- a/tests/acceptance/crud-success-test.js
+++ b/tests/acceptance/crud-success-test.js
@@ -93,12 +93,26 @@ test('Retrieve list of non-paginated records', function(assert) {
   });
 });
 
-test('Retrieve single record', function(assert) {
+test('Retrieve single record with findRecord', function(assert) {
   assert.expect(3);
 
   return Ember.run(function() {
 
     return store.findRecord('post', 1).then(function(post) {
+
+      assert.ok(post);
+      assert.equal(post.get('postTitle'), 'post title 1');
+      assert.equal(post.get('body'), 'post body 1');
+    });
+  });
+});
+
+test('Retrieve single record with queryRecord', function(assert) {
+  assert.expect(3);
+
+  return Ember.run(function() {
+
+    return store.queryRecord('post', { slug: 'post-title-1' }).then(function(post) {
 
       assert.ok(post);
       assert.equal(post.get('postTitle'), 'post title 1');

--- a/tests/acceptance/pagination-test.js
+++ b/tests/acceptance/pagination-test.js
@@ -130,6 +130,13 @@ test('Retrieve list of paginated records', function(assert) {
   });
 });
 
+test('queryRecord with paginated results returns a single record', function(assert) {
+  return store.queryRecord('post', { title: 'post title 1' }).then(function(post) {
+    assert.ok(post);
+    assert.equal(post.get('postTitle'), 'post title 1');
+    assert.equal(post.get('body'), 'post body 1');
+  });
+});
 
 test("Type metadata doesn't have previous", function(assert) {
   assert.expect(4);


### PR DESCRIPTION
When calling `store.queryRecord`, e.g.:

```js
store.queryRecord('post', { slug: 'my-post' });
```

A GET request will be sent to Django REST Framework such as:

```
GET /api/posts?slug=my-post
```

Handling this in DRF is easily done by enabling filtering in your settings:

```python
# settings.py

REST_FRAMEWORK['DEFAULT_FILTER_BACKENDS'] = (
  'rest_framework.filters.DjangoFilterBackend',
)
```

And adding the filter fields to your viewset:

```python
class PostViewSet(viewsets.ModelViewSet):

    filter_fields = ('slug',)
    ...
```

When this is done, DRF returns any records that match the filter, e.g.:

```json
[
  {"id": 123, "title": "My Post", "slug": "my-post", "content": "This is a post I wrote."}
]
```

In Ember Data, `store.queryRecord` defines itself as returning the first of multiple items if multiple items are returned.  This PR implements normalizeQueryRecordResponse to convert the DRF response to a JSON API object for Ember Data.  The first object in the array is loaded into `data`, and the remaining objects, if any, are loaded into `included` for caching.

Fixes #128 