### PR TITLE
Do not require the count attribute to be present

### DIFF
--- a/addon/serializers/drf.js
+++ b/addon/serializers/drf.js
@@ -93,7 +93,6 @@ export default DS.RESTSerializer.extend({
     let convertedPayload = {};
 
     if (!Ember.isNone(payload) &&
-      payload.hasOwnProperty('count') &&
       payload.hasOwnProperty('next') &&
       payload.hasOwnProperty('previous') &&
       payload.hasOwnProperty('results')) {


### PR DESCRIPTION
When using cursor pagination the count attribute is not included by default.
http://www.django-rest-framework.org/api-guide/pagination/#cursorpagination

This one line change is required for cursor pagination to work. The count attribute was not required before 1.0.