### PR TITLE
Support DRF not adding page query param for the previous link.

### DIFF
--- a/addon/serializers/drf.js
+++ b/addon/serializers/drf.js
@@ -108,7 +108,13 @@ export default DS.RESTSerializer.extend({
         convertedPayload.meta['next'] = this.extractPageNumber(convertedPayload.meta['next']);
       }
       if (!Ember.isNone(convertedPayload.meta['previous'])) {
-        convertedPayload.meta['previous'] = this.extractPageNumber(convertedPayload.meta['previous']);
+        let pageNumber = this.extractPageNumber(convertedPayload.meta['previous']);
+        // The DRF previous URL doesn't always include the page=1 query param in the results for page 2. We need to
+        // explicitly set previous to 1 when the previous URL is defined but the page is not set.
+        if (Ember.isNone(pageNumber)) {
+           pageNumber = 1;
+        }
+        convertedPayload.meta['previous'] = pageNumber;
       }
     } else {
       convertedPayload[primaryModelClass.modelName] = JSON.parse(JSON.stringify(payload));

--- a/tests/acceptance/pagination-test.js
+++ b/tests/acceptance/pagination-test.js
@@ -89,8 +89,11 @@ module('Acceptance: Pagination', {
 
         var previousPage = page - 1;
         var previousUrl = null;
-        if (previousPage >= 1) {
+        if (previousPage > 1) {
           previousUrl = '/test-api/posts/?page=' + previousPage;
+        } else if (previousPage === 1) {
+          // The DRF previous URL doesn't always include the page=1 query param in the results for page 2.
+          previousUrl = '/test-api/posts/';
         }
 
         var offset = (page - 1) * pageSize;


### PR DESCRIPTION
This happens on page 2 when the previous link without the page=1 query param indicates a url for page 1. I'm hitting this with `djangorestframework==3.2.4`. The test has been updated to match the output from DRF.