### PR TITLE
Do not require count attribute in response

### DIFF
--- a/addon/serializers/drf.js
+++ b/addon/serializers/drf.js
@@ -93,7 +93,6 @@ export default DS.RESTSerializer.extend({
     let convertedPayload = {};
 
     if (!Ember.isNone(payload) &&
-      payload.hasOwnProperty('count') &&
       payload.hasOwnProperty('next') &&
       payload.hasOwnProperty('previous') &&
       payload.hasOwnProperty('results')) {

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -104,6 +104,26 @@ export default DRFSerializer.extend({
 });
 ```
 
+## Cursor Pagination
+
+To use [`CursorPagination`](http://www.django-rest-framework.org/api-guide/pagination/#cursorpagination), override `extractPageNumber` in the serializer to extract the `cursor`.
+
+```js
+// app/serializer/drf.js
+
+import DRFSerializer from 'ember-django-adapter/serializers/drf';
+
+export default DRFSerializer.extend({
+  extractPageNumber: function(url) {
+    var match = /.*?[\?&]cursor=([A-Za-z0-9]+).*?/.exec(url);
+    if (match) {
+      return match[1];
+    }
+    return null;
+  }
+});
+```
+
 If you don't use the `PageNumberPagination` for pagination with DRF 3.1 you can also add
 the metadata for the pagination scheme you use here. We may add support for the other
 pagination classes in the future. If this is something you are interested in contributing,

--- a/tests/unit/serializers/drf-test.js
+++ b/tests/unit/serializers/drf-test.js
@@ -34,6 +34,34 @@ test('normalizeResponse - results', function(assert) {
   assert.equal(modifiedPayload.meta['other'], 'stuff');
 });
 
+test('normalizeResponse - results (cursor pagination)', function(assert) {
+  let serializer = this.subject();
+  serializer._super = sinon.spy();
+  let primaryModelClass = {modelName: 'person'};
+  let payload = {
+    next: '/api/posts/?page=3',
+    previous: '/api/posts/?page=1',
+    other: 'stuff',
+    results: ['result']
+  };
+
+  serializer.normalizeResponse('store', primaryModelClass, payload, 1, 'requestType');
+  assert.equal(serializer._super.callCount, 1);
+  assert.equal(serializer._super.lastCall.args[0],'store');
+  assert.propEqual(serializer._super.lastCall.args[1], primaryModelClass);
+  assert.equal(serializer._super.lastCall.args[3], 1);
+  assert.equal(serializer._super.lastCall.args[4], 'requestType');
+
+  let modifiedPayload = serializer._super.lastCall.args[2];
+  assert.equal('result', modifiedPayload[primaryModelClass.modelName][0]);
+
+  assert.ok(modifiedPayload.meta);
+  assert.equal(modifiedPayload.meta['next'], 3);
+  assert.equal(modifiedPayload.meta['previous'], 1);
+  // Unknown metadata has been passed along to the meta object.
+  assert.equal(modifiedPayload.meta['other'], 'stuff');
+});
+
 test('normalizeResponse - no results', function(assert) {
   let serializer = this.subject();
   serializer._super = sinon.stub().returns('extracted array');


### PR DESCRIPTION
I removed the requirement to have a ```count``` attribute in the DRF list response.

This closes #136 