### PR TITLE
Map payload strings to arrays

### DIFF
--- a/addon/adapters/drf.js
+++ b/addon/adapters/drf.js
@@ -137,6 +137,9 @@ export default DS.RESTAdapter.extend({
   */
   _drfToJsonAPIValidationErrors(payload, keyPrefix='') {
     let out = [];
+
+    payload = this._formatPayload(payload);
+
     for (let key in payload) {
       /*jshint loopfunc: true */
       if (payload.hasOwnProperty(key)) {
@@ -166,6 +169,27 @@ export default DS.RESTAdapter.extend({
     return out;
   },
 
+  /**
+   * This is used by RESTAdapter._drfToJsonAPIValidationErrors.
+   *
+   * Map string values to arrays because improperly formatted payloads cause
+   * a maximum call stack size exceeded error
+   *
+   * @method _formatPayload
+   * @param {Object} payload
+   * @return {Object} payload
+   */
+  _formatPayload: function(payload) {
+    for (let key in payload) {
+      if (payload.hasOwnProperty(key)) {
+        if (typeof payload[key] === 'string') {
+          payload[key] = [payload[key]];
+        }
+      }
+    }
+
+    return payload;
+  },
 
   /**
    * This is used by RESTAdapter.groupRecordsForFindMany.

--- a/tests/unit/adapters/drf-test.js
+++ b/tests/unit/adapters/drf-test.js
@@ -113,3 +113,14 @@ test('_stripIDFromURL without trailing slash - returns base URL for type', funct
 
   assert.equal(adapter._stripIDFromURL('store', snapshot), 'test-host/test-api/furry-animals');
 });
+
+test('_formatPayload returns array when string received', function(assert) {
+  var payload = {
+    key: 'value'
+  };
+  var adapter = this.subject();
+
+  assert.deepEqual(adapter._formatPayload(payload), {
+    key: ['value']
+  });
+});


### PR DESCRIPTION
Including strings in payloads causes maximum call stack size exceeded error because of the recursive nature of `_drfToJsonAPIValidationErrors`.

This PR converts:

```
{
  key: 'value'
}
```

into:

```
{
  key: ['value']
}
```

for each recursion of `_drfToJsonAPIValidationErrors`.