### PR TITLE
clean Ember.merge deprecation and fix jshintrc

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -21,12 +21,11 @@
   "nomen": false,
   "onevar": false,
   "plusplus": false,
-  "regexp": false,
   "undef": true,
   "sub": true,
   "strict": false,
   "white": false,
   "eqnull": true,
-  "esnext": true,
+  "esversion": 6,
   "unused": true
 }

--- a/addon/serializers/drf.js
+++ b/addon/serializers/drf.js
@@ -1,6 +1,8 @@
 import DS from 'ember-data';
 import Ember from 'ember';
 
+const merge = Ember.assign || Object.assign || Ember.merge;
+
 /**
  * Handle JSON/REST (de)serialization.
  *
@@ -141,7 +143,7 @@ export default DS.RESTSerializer.extend({
    * @param {Object} options
    */
   serializeIntoHash: function(hash, type, snapshot, options) {
-    Ember.merge(hash, this.serialize(snapshot, options));
+    merge(hash, this.serialize(snapshot, options));
   },
 
   /**


### PR DESCRIPTION
- Since 2.5 Ember.merge raises a deprecation. This PR fixes that and makes sure the addon would still work with versions Ember that still don't implement `assign` and in browser environments that have `Object.assign`. 
- Fix `.jshintrc` deprecated opts.