### PR TITLE
update coalesce-find-requests code sample to django-rest-framework >=3.0

### DIFF
--- a/docs/coalesce-find-requests.md
+++ b/docs/coalesce-find-requests.md
@@ -115,7 +115,7 @@ class CoalesceFilterBackend(filters.BaseFilterBackend):
 
     """
     def filter_queryset(self, request, queryset, view):
-        id_list = request.QUERY_PARAMS.getlist('ids[]')
+        id_list = request.query_params.getlist('ids[]')
         if id_list:
             # Disable pagination, so all records can load.
             view.pagination_class = None


### PR DESCRIPTION
Avoid "NotImplementedError: `request.QUERY_PARAMS` has been deprecated in favor of `request.query_params` since version 3.0, and has been fully removed as of version 3.2." when c&p'ing `CoalesceFilterBackend`.