### PR TITLE
Update ember-data to version 3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^6.6.0",
-    "ember-data": "^2.17.0",
+    "ember-data": "^3.0.0",
     "ember-inflector": "^2.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Updated to version ^3.0.0 of ember-data. Test runs fine:

```
1..69
# tests 69
# pass  69
# skip  0
# fail  0

# ok
```

The `package.json ` shows a tilde for the dependency (~3.0.0)  and not the carret version used here for ember-data installed via `ember install`. I stayed with the carret, because it has been used in the previous version.