### PR TITLE
Import adapter errors from "standard" location & make ember-data a peer dependency.

### DIFF
--- a/addon/adapters/drf.js
+++ b/addon/adapters/drf.js
@@ -1,7 +1,7 @@
 import { isArray } from '@ember/array';
 import { dasherize } from '@ember/string';
 import RESTAdapter from 'ember-data/adapters/rest';
-import { InvalidError, AdapterError } from 'ember-data/-private';
+import { InvalidError, AdapterError } from 'ember-data/adapters/errors';
 import { pluralize } from 'ember-inflector';
 
 const ERROR_MESSAGES = {

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -36,10 +36,8 @@ module.exports = function() {
         {
           name: 'ember-release',
           npm: {
-            dependencies: {
-              'ember-data': 'emberjs/data#release'
-            },
             devDependencies: {
+              'ember-data': 'latest',
               'ember-source': urls[0]
             }
           }
@@ -47,10 +45,8 @@ module.exports = function() {
         {
           name: 'ember-beta',
           npm: {
-            dependencies: {
-              'ember-data': 'emberjs/data#beta'
-            },
             devDependencies: {
+              'ember-data': 'beta',
               'ember-source': urls[1]
             }
           },
@@ -59,10 +55,8 @@ module.exports = function() {
         {
           name: 'ember-canary',
           npm: {
-            dependencies: {
-              'ember-data': 'emberjs/data#master'
-            },
             devDependencies: {
+              'ember-data': 'canary',
               'ember-source': urls[2]
             }
           },

--- a/package.json
+++ b/package.json
@@ -21,9 +21,11 @@
     "start": "ember serve",
     "test": "ember try:each"
   },
+  "peerDependencies": {
+    "ember-data": "^3.0.0"
+  },
   "dependencies": {
     "ember-cli-babel": "^6.16.0",
-    "ember-data": "^3.0.0",
     "ember-inflector": "^2.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
ember-django-adapter currently imports `AdapterError` and `InvalidError` from `ember-data/-private`, but this isn't necessary and breaks in the latest version of ember data (3.11.0).

While I was at it, I also made ember-data a peer dependency as suggested in https://github.com/dustinfarris/ember-django-adapter/issues/219. 

